### PR TITLE
Moar testing

### DIFF
--- a/.github/workflows/format_and_lint.yml
+++ b/.github/workflows/format_and_lint.yml
@@ -6,7 +6,7 @@ jobs:
   ruff:
     strategy:
       matrix:
-        python-version: ['3.9', '3.11']
+        python-version: ['3.9', '3.12']
         os: ['ubuntu-latest', 'windows-latest']
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,17 @@
 name: PyPIRelease
 
 on:
-  push:
-    tags:
-      - '*'
+  release:
+    types: [published]
 
 jobs:
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    environment:
+      name: release
+      url: https://pypi.org/p/ThermalNetwork
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
 
     steps:
       - uses: actions/checkout@v4
@@ -15,19 +19,19 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.12
 
-      - name: Install Pip Dependencies
+      - name: Install Dependencies
         shell: bash
-        run: pip install wheel
+        run: python3 -m pip install --upgrade build pip setuptools
 
       - name: Build the Wheel
         shell: bash
-        run: rm -rf dist/ build/ && python3 setup.py bdist_wheel sdist
+        run: |
+          rm -rf dist/ build/
+          python3 -m build
 
       - name: Deploy on PyPi
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.PYPIPW }}
           repository-url: https://upload.pypi.org/legacy/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.9', '3.11']
+        python-version: ['3.9', '3.12']
         os: ['ubuntu-latest', 'windows-latest']
 
     runs-on: ${{ matrix.os}}

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A library for sizing multiple ground heat exchangers distributed around a single
 
 # Usage
 
-This package is available via a command-line interface, intended to be used via URBANopt. To access the CLI directly, after installing call `thermalnetwork --help` for all the commands.
+This package has a command-line interface, intended to be used via URBANopt. To access the CLI directly, after installing call `thermalnetwork --help` for all the commands.
 
 # Developer installation
 
@@ -28,13 +28,13 @@ This package is available via a command-line interface, intended to be used via 
 
 # Testing
 
-Once you are set up as a developer, run `pytest` from the root dir.
+Once you are set up as a developer, run `pytest` from the root dir. Increase verbosity with `-v` and `-vv`.
 
-Test files are in thermalnetwork/tests/
+Test files are in _thermalnetwork/tests/_
 
-Test output will be written to thermalnetwork/tests/test_output/
+Test output will be written to _thermalnetwork/tests/test_output/_
 
 # Releasing
 
 Increment the version in thermalnetwork/_\_init__.py. Use [semantic versioning](https://semver.org/).
-When a new tag is established in GitHub, a [workflow](https://github.com/marketplace/actions/pypi-publish) automatically releases to PyPI.
+When a new release is made in GitHub, a [workflow](https://github.com/marketplace/actions/pypi-publish) automatically releases to PyPI.

--- a/README.md
+++ b/README.md
@@ -14,21 +14,26 @@ This package has a command-line interface, intended to be used via URBANopt. To 
 
 - Clone the repository: `git clone https://github.com/NREL/ThermalNetwork.git`
 - Change directories into the repository: `cd ThermalNetwork`
-- As general guidance, we recommend using virtual environments to avoid dependencies colliding between your Python projects. [venv](https://docs.python.org/3/library/venv.html) is the Python native solution that will work everywhere, though other options may be more user-friendly.
+- We recommend using virtual environments on principle to avoid dependencies colliding between your Python projects. [venv](https://docs.python.org/3/library/venv.html) is the Python native solution that will work everywhere, though other options may be more user-friendly.
     - Some popular alternatives are:
         - [pyenv](https://github.com/pyenv/pyenv) and [the virtualenv plugin](https://github.com/pyenv/pyenv-virtualenv) work together nicely for Linux/Mac machines
         - [virtualenv](https://virtualenv.pypa.io/en/latest/)
         - [miniconda](https://docs.conda.io/projects/miniconda/en/latest/)
-    - Activate pre-commit (only once, after making a new venv): `pre-commit install`
-    - Runs automatically on your staged changes before every commit
+
+Once you have set up your environment:
 - Update pip and setuptools: `pip install -U pip setuptools`
 - Install the respository with developer dependencies: `pip install -e .[dev]`
+- Activate pre-commit (only once, after making a new venv): `pre-commit install`
+    - Runs automatically on your staged changes before every commit
 - To check the whole repo, run `pre-commit run --all-files`
     - Settings and documentation links for pre-commit and ruff are in .pre-commit-config.yaml and pyproject.toml
+    - Pre-commit will run automatically during CI, linting and formatting the entire repository.
 
 # Testing
 
 Once you are set up as a developer, run `pytest` from the root dir. Increase verbosity with `-v` and `-vv`.
+
+Test coverage will be reported to stdout.
 
 Test files are in _thermalnetwork/tests/_
 
@@ -37,4 +42,4 @@ Test output will be written to _thermalnetwork/tests/test_output/_
 # Releasing
 
 Increment the version in thermalnetwork/_\_init__.py. Use [semantic versioning](https://semver.org/).
-When a new release is made in GitHub, a [workflow](https://github.com/marketplace/actions/pypi-publish) automatically releases to PyPI.
+When a new release from the `main` branch is made in GitHub, a [workflow](https://github.com/marketplace/actions/pypi-publish) automatically releases to PyPI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ]
 dependencies = [
   'click ~= 8.1',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,6 @@ line-length = 120
 
 [tool.ruff.per-file-ignores]
 "thermalnetwork/tests/*" = ["S101", "S607", "S603"] # assert statements are allowed in tests, and paths are safe
-"thermalnetwork/tests/test_base.py" = ["E501"]
 
 [project.scripts]
 thermalnetwork = "thermalnetwork.network:run_sizer_from_cli"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ line-length = 120
 
 [tool.ruff.per-file-ignores]
 "thermalnetwork/tests/*" = ["S101", "S607", "S603"] # assert statements are allowed in tests, and paths are safe
+"thermalnetwork/tests/test_base.py" = ["E501"]
 
 [project.scripts]
 thermalnetwork = "thermalnetwork.network:run_sizer_from_cli"

--- a/thermalnetwork/__init__.py
+++ b/thermalnetwork/__init__.py
@@ -1,1 +1,1 @@
-VERSION = "0.2.3-rc3"
+VERSION = "0.2.3"

--- a/thermalnetwork/__init__.py
+++ b/thermalnetwork/__init__.py
@@ -1,1 +1,1 @@
-VERSION = "0.2.3-rc1"
+VERSION = "0.2.3-rc3"

--- a/thermalnetwork/tests/test_base.py
+++ b/thermalnetwork/tests/test_base.py
@@ -6,9 +6,9 @@ from pathlib import Path
 class BaseCase(unittest.TestCase):
     def setUp(self) -> None:
         here = Path(__file__).parent
+
+        # -- Input paths
         self.demos_path = here.parent.parent / "demos"
-        self.test_outputs_path = here.resolve() / "test_outputs"
-        self.test_outputs_path.mkdir(exist_ok=True)
 
         self.geojson_file_path_1_ghe = (self.demos_path / "sdk_output_skeleton_1_ghe" / "network.geojson").resolve()
         self.scenario_directory_path_1_ghe = (
@@ -27,6 +27,10 @@ class BaseCase(unittest.TestCase):
         self.system_parameter_path_2_ghe = (
             self.scenario_directory_path_2_ghe / "ghe_dir" / "sys_params.json"
         ).resolve()
+
+        # -- Output paths
+        self.test_outputs_path = here.resolve() / "test_outputs"
+        self.test_outputs_path.mkdir(exist_ok=True)
 
         # Save the original borehole length and number of boreholes, so they can be restored after the tests run.
         sys_param_1_ghe = json.loads((self.system_parameter_path_1_ghe).read_text())

--- a/thermalnetwork/tests/test_base.py
+++ b/thermalnetwork/tests/test_base.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 from pathlib import Path
 
@@ -8,3 +9,31 @@ class BaseCase(unittest.TestCase):
         self.demos_path = here.parent.parent / "demos"
         self.test_outputs_path = here.resolve() / "test_outputs"
         self.test_outputs_path.mkdir(exist_ok=True)
+
+        self.geojson_file_path_1_ghe = (self.demos_path / "sdk_output_skeleton_1_ghe" / "network.geojson").resolve()
+        self.scenario_directory_path_1_ghe = (
+            self.demos_path / "sdk_output_skeleton_1_ghe" / "run" / "baseline_scenario"
+        ).resolve()
+        self.system_parameter_path_1_ghe = (
+            self.scenario_directory_path_1_ghe / "ghe_dir" / "sys_params.json"
+        ).resolve()
+
+        self.geojson_file_path_2_ghe = (
+            self.demos_path / "sdk_output_skeleton_2_ghe_sequential" / "network.geojson"
+        ).resolve()
+        self.scenario_directory_path_2_ghe = (
+            self.demos_path / "sdk_output_skeleton_2_ghe_sequential" / "run" / "baseline_scenario"
+        ).resolve()
+        self.system_parameter_path_2_ghe = (
+            self.scenario_directory_path_2_ghe / "ghe_dir" / "sys_params.json"
+        ).resolve()
+
+        # Save the original borehole length and number of boreholes, so they can be restored after the tests run.
+        sys_param_1_ghe = json.loads((self.system_parameter_path_1_ghe).read_text())
+        one_ghe_specific_params = sys_param_1_ghe["district_system"]["fifth_generation"]["ghe_parameters"][
+            "ghe_specific_params"
+        ]
+        for ghe in one_ghe_specific_params:
+            # These values are the same across all our demo files.
+            self.original_borehole_length = ghe["borehole"]["length_of_boreholes"]
+            self.original_num_boreholes = ghe["borehole"]["number_of_boreholes"]

--- a/thermalnetwork/tests/test_ground_heat_exchanger.py
+++ b/thermalnetwork/tests/test_ground_heat_exchanger.py
@@ -1,18 +1,16 @@
-# from unittest import TestCase
-#
-# from thermalnetwork.ground_heat_exchanger import GHE
-#
-#
-# class TestGHE(TestCase):
-#     def test_calc_src_side_load(self):
-#         data = {
-#             "name": "GHE",
-#             "type": "GROUNDHEATEXCHANGER",
-#             "properties": {
-#                 "length": 20,
-#                 "width": 50
-#             }
-#         }
-#         ghe = GHE(data)
-#         self.assertEquals(ghe.name, 'GHE')
-#         self.assertEquals(ghe.area, 1000)
+from thermalnetwork.ground_heat_exchanger import GHE
+from thermalnetwork.tests.test_base import BaseCase
+
+
+class TestGHE(BaseCase):
+    def test_calc_src_side_load(self):
+        data = {
+            "name": "GHE",
+            "id": "asdfjkl;",
+            "type": "GROUNDHEATEXCHANGER",
+            "properties": {"geometric_constraints": {"length": 20, "width": 50}},
+        }
+        ghe = GHE(data)
+        assert ghe.name == "GHE"
+        assert ghe.area == 1000
+        assert ghe.id == "asdfjkl;"

--- a/thermalnetwork/tests/test_ground_heat_exchanger.py
+++ b/thermalnetwork/tests/test_ground_heat_exchanger.py
@@ -4,13 +4,18 @@ from thermalnetwork.tests.test_base import BaseCase
 
 class TestGHE(BaseCase):
     def test_calc_src_side_load(self):
+        # -- Set up
         data = {
             "name": "GHE",
             "id": "asdfjkl;",
             "type": "GROUNDHEATEXCHANGER",
             "properties": {"geometric_constraints": {"length": 20, "width": 50}},
         }
+
+        # -- Run
         ghe = GHE(data)
+
+        # -- Check
         assert ghe.name == "GHE"
         assert ghe.area == 1000
         assert ghe.id == "asdfjkl;"

--- a/thermalnetwork/tests/test_heat_pump.py
+++ b/thermalnetwork/tests/test_heat_pump.py
@@ -1,11 +1,10 @@
-from unittest import TestCase
-
 import pytest
 
 from thermalnetwork.heat_pump import HeatPump
+from thermalnetwork.tests.test_base import BaseCase
 
 
-class TestHeatPump(TestCase):
+class TestHeatPump(BaseCase):
     def test_calc_src_side_load(self):
         data = {"name": "WSHP", "type": "HEATPUMP", "properties": {"cop_c": 3.5, "cop_h": 2.5}}
 

--- a/thermalnetwork/tests/test_heat_pump.py
+++ b/thermalnetwork/tests/test_heat_pump.py
@@ -6,9 +6,13 @@ from thermalnetwork.tests.test_base import BaseCase
 
 class TestHeatPump(BaseCase):
     def test_calc_src_side_load(self):
+        # -- Set up
         data = {"name": "WSHP", "type": "HEATPUMP", "properties": {"cop_c": 3.5, "cop_h": 2.5}}
 
+        # -- Run
         hp = HeatPump(data)
+
+        # -- Check
         assert hp.name == "WSHP"
         assert hp.calc_src_side_load(1) == pytest.approx(0.60, 0.01)
         assert hp.calc_src_side_load(-1) == pytest.approx(-1.28, 0.01)

--- a/thermalnetwork/tests/test_network.py
+++ b/thermalnetwork/tests/test_network.py
@@ -1,5 +1,7 @@
 import json
 
+import pytest
+
 from thermalnetwork.network import run_sizer_from_cli_worker
 from thermalnetwork.tests.test_base import BaseCase
 
@@ -37,6 +39,7 @@ class TestNetwork(BaseCase):
             # Restore the trailing newline
             sys_param_file.write("\n")
 
+    @pytest.mark.skip(reason="Test consumes too much memory/cpu for GHA runners. Please run locally instead")
     def test_network_two_ghe(self):
         output_path = self.test_outputs_path / "two_ghe"
         output_path.mkdir(parents=True, exist_ok=True)

--- a/thermalnetwork/tests/test_network.py
+++ b/thermalnetwork/tests/test_network.py
@@ -8,9 +8,11 @@ from thermalnetwork.tests.test_base import BaseCase
 
 class TestNetwork(BaseCase):
     def test_network_one_ghe(self):
+        # -- Set up
         output_path = self.test_outputs_path / "one_ghe"
         output_path.mkdir(parents=True, exist_ok=True)
 
+        # -- Run
         run_sizer_from_cli_worker(
             self.system_parameter_path_1_ghe,
             self.scenario_directory_path_1_ghe,
@@ -18,6 +20,7 @@ class TestNetwork(BaseCase):
             output_path,
         )
 
+        # -- Check
         for ghe_id in output_path.iterdir():
             sim_summary = json.loads((ghe_id / "SimulationSummary.json").read_text())
 
@@ -26,6 +29,7 @@ class TestNetwork(BaseCase):
         # ie: sim_summary["ghe_system"]["active_borehole_length"]["value"] should not only be a number,
         # but the CORRECT number.
 
+        # -- Clean up
         # Restore the original borehole length and number of boreholes.
         sys_param_1_ghe = json.loads((self.system_parameter_path_1_ghe).read_text())
         one_ghe_specific_params = sys_param_1_ghe["district_system"]["fifth_generation"]["ghe_parameters"][
@@ -41,9 +45,11 @@ class TestNetwork(BaseCase):
 
     @pytest.mark.skip(reason="Test consumes too much memory/cpu for GHA runners. Please run locally instead")
     def test_network_two_ghe(self):
+        # -- Set up
         output_path = self.test_outputs_path / "two_ghe"
         output_path.mkdir(parents=True, exist_ok=True)
 
+        # -- Run
         run_sizer_from_cli_worker(
             self.system_parameter_path_2_ghe,
             self.scenario_directory_path_2_ghe,
@@ -51,6 +57,7 @@ class TestNetwork(BaseCase):
             output_path,
         )
 
+        # -- Check
         for ghe_id in output_path.iterdir():
             sim_summary = json.loads((ghe_id / "SimulationSummary.json").read_text())
 
@@ -59,6 +66,7 @@ class TestNetwork(BaseCase):
         # ie: sim_summary["ghe_system"]["active_borehole_length"]["value"] should not only be a number,
         # but the CORRECT number.
 
+        # -- Clean up
         # Restore the original borehole length and number of boreholes.
         sys_param_2_ghe = json.loads((self.system_parameter_path_2_ghe).read_text())
         two_ghe_specific_params = sys_param_2_ghe["district_system"]["fifth_generation"]["ghe_parameters"][

--- a/thermalnetwork/tests/test_network.py
+++ b/thermalnetwork/tests/test_network.py
@@ -1,37 +1,73 @@
+import json
+
 from thermalnetwork.network import run_sizer_from_cli_worker
 from thermalnetwork.tests.test_base import BaseCase
 
 
 class TestNetwork(BaseCase):
     def test_network_one_ghe(self):
-        geojson_file_path = self.demos_path / "sdk_output_skeleton" / "example_project_combine_GHE.json"
-        geojson_file_path = geojson_file_path.resolve()
-
-        scenario_directory_path = self.demos_path / "sdk_output_skeleton" / "run" / "baseline_scenario"
-        scenario_directory_path.resolve()
-
-        system_parameter_path = scenario_directory_path / "ghe_dir" / "system_parameter.json"
-        system_parameter_path.resolve()
-
         output_path = self.test_outputs_path / "one_ghe"
         output_path.mkdir(parents=True, exist_ok=True)
 
-        run_sizer_from_cli_worker(system_parameter_path, scenario_directory_path, geojson_file_path, output_path)
+        run_sizer_from_cli_worker(
+            self.system_parameter_path_1_ghe,
+            self.scenario_directory_path_1_ghe,
+            self.geojson_file_path_1_ghe,
+            output_path,
+        )
+
+        for ghe_id in output_path.iterdir():
+            sim_summary = json.loads((ghe_id / "SimulationSummary.json").read_text())
+
+            assert isinstance(sim_summary["ghe_system"]["active_borehole_length"]["value"], float)
+        # TODO: We should test the quality of the output.
+        # ie: sim_summary["ghe_system"]["active_borehole_length"]["value"] should not only be a number,
+        # but the CORRECT number.
+
+        # Restore the original borehole length and number of boreholes.
+        sys_param_1_ghe = json.loads((self.system_parameter_path_1_ghe).read_text())
+        one_ghe_specific_params = sys_param_1_ghe["district_system"]["fifth_generation"]["ghe_parameters"][
+            "ghe_specific_params"
+        ]
+        for ghe in one_ghe_specific_params:
+            ghe["borehole"]["length_of_boreholes"] = self.original_borehole_length
+            ghe["borehole"]["number_of_boreholes"] = self.original_num_boreholes
+        with open(self.system_parameter_path_1_ghe, "w") as sys_param_file:
+            json.dump(sys_param_1_ghe, sys_param_file, indent=2)
+            # Restore the trailing newline
+            sys_param_file.write("\n")
 
     def test_network_two_ghe(self):
-        geojson_file_path = self.demos_path / "sdk_output_skeleton" / "example_project_combine_GHE_2.json"
-        geojson_file_path = geojson_file_path.resolve()
-
-        scenario_directory_path = self.demos_path / "sdk_output_skeleton" / "run" / "baseline_scenario"
-        scenario_directory_path.resolve()
-
-        system_parameter_path = scenario_directory_path / "ghe_dir" / "system_parameter.json"
-        system_parameter_path.resolve()
-
         output_path = self.test_outputs_path / "two_ghe"
         output_path.mkdir(parents=True, exist_ok=True)
 
-        run_sizer_from_cli_worker(system_parameter_path, scenario_directory_path, geojson_file_path, output_path)
+        run_sizer_from_cli_worker(
+            self.system_parameter_path_2_ghe,
+            self.scenario_directory_path_2_ghe,
+            self.geojson_file_path_2_ghe,
+            output_path,
+        )
+
+        for ghe_id in output_path.iterdir():
+            sim_summary = json.loads((ghe_id / "SimulationSummary.json").read_text())
+
+            assert isinstance(sim_summary["ghe_system"]["active_borehole_length"]["value"], float)
+        # TODO: We should test the quality of the output.
+        # ie: sim_summary["ghe_system"]["active_borehole_length"]["value"] should not only be a number,
+        # but the CORRECT number.
+
+        # Restore the original borehole length and number of boreholes.
+        sys_param_2_ghe = json.loads((self.system_parameter_path_2_ghe).read_text())
+        two_ghe_specific_params = sys_param_2_ghe["district_system"]["fifth_generation"]["ghe_parameters"][
+            "ghe_specific_params"
+        ]
+        for ghe in two_ghe_specific_params:
+            ghe["borehole"]["length_of_boreholes"] = self.original_borehole_length
+            ghe["borehole"]["number_of_boreholes"] = self.original_num_boreholes
+        with open(self.system_parameter_path_2_ghe, "w") as sys_param_file:
+            json.dump(sys_param_2_ghe, sys_param_file, indent=2)
+            # Restore the trailing newline
+            sys_param_file.write("\n")
 
 
 #    def test_network_two_ghe_no_load(self):


### PR DESCRIPTION
_DISCUSSION!_ Running our `two_ghe` test takes too much memory/cpu for the (free) GHA runner, which cancels the test. Googling around found https://github.com/actions/runner-images/issues/6680 which explains it. This implies our options are:
1. Splash cash for bigger runners
1. Honey I shrunk the test
1. Not run the `two_ghe` test (at least comment it so it doesn't run automatically on CI)

I think option 3 is the best combination of low cost but still allows us to run the test locally. @mitchute wat do?

Some of the tests weren't running because the paths were outdated. This PR:
- Fixes the paths
    - And DRYed up the paths
- Added some assertions to the network tests
    - And handled the fact that we now re-write the sys-param files in-place
- Revived the GHE test that was commented
- Adds support for Python 3.12
- Adds comments for developer clarity
- Clarifies & updates the readme
- Officially updates version to 0.2.3