### PR TITLE
Use newer release workflow tools recommended by PyPA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -15,15 +15,17 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.12
 
-      - name: Install Pip Dependencies
+      - name: Install Dependencies
         shell: bash
-        run: pip install wheel
+        run: python3 -m pip install --upgrade build
 
       - name: Build the Wheel
         shell: bash
-        run: rm -rf dist/ build/ && python3 setup.py bdist_wheel sdist
+        run: |
+          rm -rf dist/ build/
+          python3 -m build
 
       - name: Deploy on PyPi
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,17 @@
 name: PyPIRelease
 
 on:
-  push:
-    tags:
-      - '*'
+  release:
+    types: [published]
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment:
+      name: release
+      url: https://pypi.org/p/ThermalNetwork
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
 
     steps:
       - uses: actions/checkout@v4
@@ -30,6 +34,4 @@ jobs:
       - name: Deploy on PyPi
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.PYPIPW }}
           repository-url: https://upload.pypi.org/legacy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Install Dependencies
         shell: bash
-        run: python3 -m pip install --upgrade build
+        run: python3 -m pip install --upgrade build pip setuptools
 
       - name: Build the Wheel
         shell: bash

--- a/thermalnetwork/__init__.py
+++ b/thermalnetwork/__init__.py
@@ -1,1 +1,1 @@
-VERSION = "0.2.3-rc1"
+VERSION = "0.2.3-rc2"

--- a/thermalnetwork/__init__.py
+++ b/thermalnetwork/__init__.py
@@ -1,1 +1,1 @@
-VERSION = "0.2.3-rc2"
+VERSION = "0.2.3-rc3"


### PR DESCRIPTION
Use currently accepted package build guidelines from PyPA: https://packaging.python.org/en/latest/tutorials/packaging-projects/#generating-distribution-archives that will be used by the GHA to upload to PyPI