### PR TITLE
Set up automatic changelog generation at Github release time

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,22 @@
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuration-options
+
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+      - DO NOT MERGE
+      - invalid
+      - tests
+    authors:
+      - octocat
+      - dependabot
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - breaking-change
+    - title: Exciting New Features 🎉
+      labels:
+        - enhancement
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
#### Any background context you want to provide?
Github has a system for automatically writing a changelog for us when we make a release. It does this by categorizing PRs by their label, so we need to be good about labeling our PRs in Github. Changelogs are easier to maintain when Github does it all for us.
#### What does this PR accomplish?
- Creates a new config file to tell Github how to categorize PRs
#### How should this be manually tested?
At the next release, press the `generate release notes` button and see if it categorizes the PRs appropriately
#### What are the relevant tickets?
<!--Add the issue numbers like this: Resolves #100 Resolves #101 to automatically connect your PR to 1+ issues. -->
#### Screenshots (if appropriate)
