### PR TITLE
Fix Mismatch in Flow Rates 

### DIFF
--- a/thermalnetwork/ground_heat_exchanger.py
+++ b/thermalnetwork/ground_heat_exchanger.py
@@ -66,7 +66,7 @@ class GHE(BaseComponent):
             b_max=self.json_data["geometric_constraints"]["b_max"],
         )
         ghe.set_design(
-            flow_rate=self.json_data["design"]["flow_rate"], flow_type_str=self.json_data["design"]["flow_type"]
+            flow_rate=self.json_data["design"]["flow_rate"] * 1000, flow_type_str=self.json_data["design"]["flow_type"]
         )
 
         output_file_directory = output_path / self.id


### PR DESCRIPTION
URBANopt/ThermalNetwork pass flow rates in m3/s, whereas GHEDesigner are expecting them in lps. This corrects the units.
