### PR TITLE
checkout with tags to help setuptools-scm find version

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-tags: True
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-tags: true
+          fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-tags: True
+          fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -13,8 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 1
-          fetch-tags: true
+          fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -13,7 +13,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
+          fetch-tags: true
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -12,6 +12,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-tags: true
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
#### Any background context you want to provide?
actions/checkout doesn't check out the entire repo history by default, so it missed the GH tags that we use for versioning. This can be resolved by checking out the full history. I'm not thrilled with this solution, as this won't scale well for a large repo. I guess it's good for now.

There is an option to use `fetch-tags` with [the action](https://github.com/actions/checkout/) which doesn't seem to work as a standalone option. It might be intended to use in addition to a specific depth (number of commits) but I'm not sure that is appropriate for our use case. This should be revisited if/when it becomes a problem (meaning CI takes a lot of time/memory to checkout).
#### What does this PR accomplish?
Checks out full repo history in CI, so the version is displayed correctly
#### How should this be manually tested?
CI is sufficient. 
#### What are the relevant tickets?
<!--Add the issue numbers like this: Resolves #100 Resolves #101 to automatically connect your PR to 1+ issues. -->
Resolves #20 
#### Screenshots (if appropriate)
