### PR TITLE
Improve ordering and handling of upstream sizing method

### DIFF
--- a/demos/sdk_output_skeleton_13_buildings/exportGeo.json
+++ b/demos/sdk_output_skeleton_13_buildings/exportGeo.json
@@ -772,8 +772,7 @@
         "type": "ThermalJunction",
         "DSId": "344421ab-b416-403e-bd22-7b8af7b581a2",
         "junction_type": "DES",
-        "connection_type": "Series",
-        "is_ghe_start_loop": true
+        "connection_type": "Series"
       },
       "geometry": {
         "type": "Point",
@@ -835,7 +834,8 @@
         "type": "ThermalJunction",
         "buildingId": "10",
         "junction_type": "DES",
-        "connection_type": "Series"
+        "connection_type": "Series",
+        "is_ghe_start_loop": true
       },
       "geometry": {
         "type": "Point",

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -24,7 +24,7 @@ class TestNetwork(BaseCase):
         for ghe_id in output_path.iterdir():
             sim_summary = json.loads((ghe_id / "SimulationSummary.json").read_text())
 
-            assert sim_summary["ghe_system"]["active_borehole_length"]["value"] == pytest.approx(133.5, 0.01)
+            assert sim_summary["ghe_system"]["active_borehole_length"]["value"] == pytest.approx(110, 0.1)
 
         # -- Clean up
         # Restore the original borehole length and number of boreholes.
@@ -95,7 +95,7 @@ class TestNetwork(BaseCase):
             assert sim_summary["ghe_system"]["active_borehole_length"]["value"] == pytest.approx(133, 2)
         # FIXME: 135 is the max borehole length for a GHE (as set in the sys-params file).
         # This implies the borefield size is too small.
-        # Borefield dimensions are set in the geojson file and transfered to the sys-params file.
+        # Borefield dimensions are set in the geojson file and transfered to the sys-params file by the GMT.
 
         # -- Clean up
         # Restore the original borehole length and number of boreholes.
@@ -128,11 +128,10 @@ class TestNetwork(BaseCase):
         for ghe_id in output_path.iterdir():
             sim_summary = json.loads((ghe_id / "SimulationSummary.json").read_text())
 
-            # assert isinstance(sim_summary["ghe_system"]["active_borehole_length"]["value"], float)
             assert sim_summary["ghe_system"]["active_borehole_length"]["value"] == pytest.approx(133, 2)
         # FIXME: 135 is the max borehole length for a GHE (as set in the sys-params file).
         # This implies the borefield size is too small.
-        # Borefield dimensions are set in the geojson file and transfered to the sys-params file.
+        # Borefield dimensions are set in the geojson file and transfered to the sys-params file by the GMT.
 
         # -- Clean up
         # Restore the original borehole length and number of boreholes.

--- a/thermalnetwork/network.py
+++ b/thermalnetwork/network.py
@@ -66,7 +66,7 @@ class Network:
         # Find the feature that has been labelled as the start of the loop
         # TODO: Update the UI to allow the user to select the start loop feature.
         connected_features = [
-            feature["properties"]["buildingId"] or feature["properties"]["DSId"]
+            feature["properties"].get("buildingId") or feature["properties"].get("DSId")
             for feature in self.geojson_data["features"]
             if feature["properties"].get("is_ghe_start_loop")
         ]

--- a/thermalnetwork/network.py
+++ b/thermalnetwork/network.py
@@ -37,14 +37,14 @@ class Network:
         self.geojson_data: dict = {}
         self.scenario_directory_path: Path = Path()
 
-    def find_startloop_feature_id(self, features):
+    def find_startloop_feature_id(self):
         """
         Finds the feature ID of a feature with the 'is_ghe_start_loop' property set to True in a list of features.
 
         :param features: List of features to search for the start loop feature.
         :return: The feature ID of the start loop feature, or None if not found.
         """
-        for feature in features:
+        for feature in self.geojson_data["features"]:
             if feature["properties"].get("is_ghe_start_loop"):
                 start_feature_id = feature["properties"].get("buildingId") or feature["properties"].get("DSId")
                 return start_feature_id
@@ -57,7 +57,7 @@ class Network:
         :return: List of connected features with additional information.
         """
         features = self.geojson_data["features"]
-        startloop_feature_id = self.find_startloop_feature_id(self.geojson_data["features"])
+        startloop_feature_id = self.find_startloop_feature_id()
         # List thermal connections
         connectors = [
             feature for feature in self.geojson_data["features"] if feature["properties"]["type"] == "ThermalConnector"

--- a/thermalnetwork/network.py
+++ b/thermalnetwork/network.py
@@ -92,11 +92,13 @@ class Network:
                             "id": feature_id,
                             "type": feature["properties"]["type"],
                             "name": feature["properties"].get("name", ""),
-                            "district_system_type": feature["properties"].get("district_system_type", ""),
+                            "district_system_type": feature["properties"].get("district_system_type"),
                             "properties": {
-                                k: v for k, v in feature["properties"].items() if k not in ["type", "name", "id"]
+                                k: v
+                                for k, v in feature["properties"].items()
+                                if k not in ["type", "name", "id", "district_system_type"]
                             },
-                            "is_ghe_start_loop": True if feature_id == startloop_feature_id else None,
+                            "is_ghe_start_loop": feature_id == startloop_feature_id,
                         }
                     )
 

--- a/thermalnetwork/network.py
+++ b/thermalnetwork/network.py
@@ -75,9 +75,9 @@ class Network:
                     break
 
             if next_feature_id:
-                connected_features.append(next_feature_id)
                 if next_feature_id == start_feature_id:
                     break
+                connected_features.append(next_feature_id)
             else:
                 break
 


### PR DESCRIPTION
#### Any background context you want to provide?
The order for the upstream design method was improved in #25 but not completely. This completes that work so all loads are allocated appropriately to GHEs.
#### What does this PR accomplish?
- Restore usage of reorder_connected_features that was removed in #25 
- Move ghe_start_loop to a building and not a GHE
- Clean up connected_objects
#### How should this be manually tested?
CI is sufficient
#### What are the relevant tickets?
Resolves #23 
