### PR TITLE
Relax dependencies a little to improve interoperability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,8 @@ classifiers = [
 dependencies = [
   'click ~= 8.1',
   'ghedesigner ~= 1.4',
-  'pandas ~= 2.1',
-  "rich ~= 13.6",
+  'pandas ~= 2.0',
+  "rich ~= 13.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
#### Any background context you want to provide?
Urbanopt has dependency conflicts, specifically with Pandas. Relaxing these constraints will make it easier for all the projects that Urbanopt uses to play nicely together.
#### What does this PR accomplish?
Uses [compatible versioning](https://packaging.python.org/en/latest/specifications/version-specifiers/#compatible-release) to maintain backward compatibility while allowing the newest mutual version to be used.
#### How should this be manually tested?
CI is sufficient
#### What are the relevant tickets?
https://github.com/urbanopt/urbanopt-cli/issues/459
