### PR TITLE
Prep 0.2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,14 @@ This package has a command-line interface, intended to be used via URBANopt. To 
         - [pyenv](https://github.com/pyenv/pyenv) and [the virtualenv plugin](https://github.com/pyenv/pyenv-virtualenv) work together nicely for Linux/Mac machines
         - [virtualenv](https://virtualenv.pypa.io/en/latest/)
         - [miniconda](https://docs.conda.io/projects/miniconda/en/latest/)
+        - [rye](https://rye-up.com/)
 
 Once you have set up your environment:
 - Update pip and setuptools: `pip install -U pip setuptools`
 - Install the respository with developer dependencies: `pip install -e .[dev]`
 - Activate pre-commit (only once, after making a new venv): `pre-commit install`
     - Runs automatically on your staged changes before every commit
+    - Includes linting and formatting via [ruff](https://docs.astral.sh/ruff/)
 - To check the whole repo, run `pre-commit run --all-files`
     - Settings and documentation links for pre-commit and ruff are in .pre-commit-config.yaml and pyproject.toml
     - Pre-commit will run automatically during CI, linting and formatting the entire repository.
@@ -33,11 +35,11 @@ Once you have set up your environment:
 
 Once you are set up as a developer, run `pytest` from the root dir. Increase verbosity with `-v` and `-vv`.
 
-Test coverage will be reported to stdout.
+Test coverage results will be saved to _htmlcov/index.html_.
 
-Test files are in _thermalnetwork/tests/_
+Test files are in _tests/_
 
-Test output will be written to _thermalnetwork/tests/test_output/_
+Test output will be written to _tests/test_output/_
 
 # Releasing
 

--- a/demos/sdk_output_skeleton_13_buildings/run/baseline_scenario/ghe_dir/sys_params_proportional.json
+++ b/demos/sdk_output_skeleton_13_buildings/run/baseline_scenario/ghe_dir/sys_params_proportional.json
@@ -511,7 +511,7 @@
   "district_system": {
     "fifth_generation": {
       "ghe_parameters": {
-        "version": "0.2.4",
+        "version": "0.2.5",
         "ghe_dir": "../ccc/run/baseline_scenario/ghe_dir",
         "fluid": {
           "fluid_name": "Water",

--- a/demos/sdk_output_skeleton_13_buildings/run/baseline_scenario/ghe_dir/sys_params_upstream.json
+++ b/demos/sdk_output_skeleton_13_buildings/run/baseline_scenario/ghe_dir/sys_params_upstream.json
@@ -511,7 +511,7 @@
   "district_system": {
     "fifth_generation": {
       "ghe_parameters": {
-        "version": "0.2.4",
+        "version": "0.2.5",
         "ghe_dir": "../ccc/run/baseline_scenario/ghe_dir",
         "fluid": {
           "fluid_name": "Water",

--- a/demos/sdk_output_skeleton_1_ghe/run/baseline_scenario/ghe_dir/sys_params.json
+++ b/demos/sdk_output_skeleton_1_ghe/run/baseline_scenario/ghe_dir/sys_params.json
@@ -88,7 +88,7 @@
   "district_system": {
     "fifth_generation": {
       "ghe_parameters": {
-        "version": "0.2.4",
+        "version": "0.2.5",
         "ghe_dir": "tests\\management\\data\\sdk_project_scraps\\run\\baseline_scenario\\ghe_dir",
         "fluid": {
           "fluid_name": "Water",

--- a/demos/sdk_output_skeleton_2_ghe_sequential/run/baseline_scenario/ghe_dir/sys_params.json
+++ b/demos/sdk_output_skeleton_2_ghe_sequential/run/baseline_scenario/ghe_dir/sys_params.json
@@ -88,7 +88,7 @@
   "district_system": {
     "fifth_generation": {
       "ghe_parameters": {
-        "version": "0.2.4",
+        "version": "0.2.5",
         "ghe_dir": "tests\\management\\data\\sdk_project_scraps\\run\\baseline_scenario\\ghe_dir",
         "fluid": {
           "fluid_name": "Water",

--- a/demos/sdk_output_skeleton_2_ghe_staggered/run/baseline_scenario/ghe_dir/sys_params.json
+++ b/demos/sdk_output_skeleton_2_ghe_staggered/run/baseline_scenario/ghe_dir/sys_params.json
@@ -88,7 +88,7 @@
   "district_system": {
     "fifth_generation": {
       "ghe_parameters": {
-        "version": "0.2.4",
+        "version": "0.2.5",
         "ghe_dir": "ghe\\run\\baseline_scenario\\ghe_dir",
         "fluid": {
           "fluid_name": "Water",


### PR DESCRIPTION
#### Any background context you want to provide?
Preparation steps for the next patch release

@mitchute: We're not under the urbanopt org, but should we adopt their license anyway? [This](https://github.com/urbanopt/geojson-modelica-translator/blob/develop/LICENSE.md) is an example. If not, should we bump the date on our license, or put a range of dates (2022 - 2024)?
#### What does this PR accomplish?
- Updates readme with some new info and fixing some outdated paths
- Bumps TN version in the test sys-param files so they'll be happy when we make the release to 0.2.5
