### PR TITLE
Add pre-commit hook to fix typos

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,10 @@ repos:
     # hooks:
       # - id: check-useless-excludes # Ensure the exclude syntax is correct
       # - id: check-hooks-apply # Fails if a hook doesn't apply to any file
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.22.9
+    hooks:
+      - id: typos
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.5.0
     hooks:
@@ -34,7 +38,3 @@ repos:
       # Run the formatter
       - id: ruff-format
         types_or: [python, pyi, jupyter]
-  - repo: https://github.com/crate-ci/typos
-    rev: v1.22.9
-    hooks:
-      - id: typos

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
       # - id: check-useless-excludes # Ensure the exclude syntax is correct
       # - id: check-hooks-apply # Fails if a hook doesn't apply to any file
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.6
+    rev: v0.5.0
     hooks:
       # Run the linter
       - id: ruff
@@ -35,6 +35,6 @@ repos:
       - id: ruff-format
         types_or: [python, pyi, jupyter]
   - repo: https://github.com/crate-ci/typos
-    rev: v1.21.0
+    rev: v1.22.9
     hooks:
       - id: typos

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-ast
       - id: check-added-large-files
@@ -25,7 +25,7 @@ repos:
       # - id: check-useless-excludes # Ensure the exclude syntax is correct
       # - id: check-hooks-apply # Fails if a hook doesn't apply to any file
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.5
+    rev: v0.4.6
     hooks:
       # Run the linter
       - id: ruff
@@ -34,3 +34,7 @@ repos:
       # Run the formatter
       - id: ruff-format
         types_or: [python, pyi, jupyter]
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.21.0
+    hooks:
+      - id: typos

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This package has a command-line interface, intended to be used via URBANopt. To 
 
 Once you have set up your environment:
 - Update pip and setuptools: `pip install -U pip setuptools`
-- Install the respository with developer dependencies: `pip install -e .[dev]`
+- Install the repository with developer dependencies: `pip install -e .[dev]`
 - Activate pre-commit (only once, after making a new venv): `pre-commit install`
     - Runs automatically on your staged changes before every commit
     - Includes linting and formatting via [ruff](https://docs.astral.sh/ruff/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ dev = [
     "pytest >= 6.0",
     "pytest-cov ~= 4.1",
     "pre-commit ~= 3.5",
-    "ruff ~= 0.3",
     "jupyterlab ~= 4.0",
 ]
 

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -95,7 +95,7 @@ class TestNetwork(BaseCase):
             assert sim_summary["ghe_system"]["active_borehole_length"]["value"] == pytest.approx(133, 2)
         # FIXME: 135 is the max borehole length for a GHE (as set in the sys-params file).
         # This implies the borefield size is too small.
-        # Borefield dimensions are set in the geojson file and transfered to the sys-params file by the GMT.
+        # Borefield dimensions are set in the geojson file and transferred to the sys-params file by the GMT.
 
         # -- Clean up
         # Restore the original borehole length and number of boreholes.
@@ -131,7 +131,7 @@ class TestNetwork(BaseCase):
             assert sim_summary["ghe_system"]["active_borehole_length"]["value"] == pytest.approx(133, 2)
         # FIXME: 135 is the max borehole length for a GHE (as set in the sys-params file).
         # This implies the borefield size is too small.
-        # Borefield dimensions are set in the geojson file and transfered to the sys-params file by the GMT.
+        # Borefield dimensions are set in the geojson file and transferred to the sys-params file by the GMT.
 
         # -- Clean up
         # Restore the original borehole length and number of boreholes.


### PR DESCRIPTION
#### Any background context you want to provide?
Adding an automatic check to protect developers from ourselves.
#### What does this PR accomplish?
- Adds a hook to scan for and fix typos
- Bumps existing hook versions
- Removes Ruff from dev dependencies. It was never necessary because pre-commit installs and runs it separately
#### How should this be manually tested?
CI is sufficient, because it will run pre-commit. As usual, if you want to run pre-commit yourself, you can scan the entire repo with `pre-commit run --all-files`
#### What are the relevant tickets?
<!--Add the issue numbers like this: Resolves #100 Resolves #101 to automatically connect your PR to 1+ issues. -->
#### Screenshots (if appropriate)
