### PR TITLE
remove support for Python 3.9

### DIFF
--- a/.github/workflows/format_and_lint.yml
+++ b/.github/workflows/format_and_lint.yml
@@ -6,7 +6,7 @@ jobs:
   ruff:
     strategy:
       matrix:
-        python-version: ['3.9', '3.12']
+        python-version: ['3.10', '3.12']
         os: ['ubuntu-latest', 'windows-latest']
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.9', '3.12']
+        python-version: ['3.10', '3.12']
         os: ['ubuntu-latest', 'windows-latest']
 
     runs-on: ${{ matrix.os}}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,12 +18,11 @@ authors = [
   { name="Nathan Moore", email="nathan.moore@nrel.gov" },
 ]
 description = "A thermal network solver for GHE sizing."
-requires-python = ">=3.9,<3.13"
+requires-python = ">=3.10,<3.13"
 classifiers = [
         "Development Status :: 4 - Beta",
         "Topic :: Scientific/Engineering",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",

--- a/thermalnetwork/base_component.py
+++ b/thermalnetwork/base_component.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from thermalnetwork.enums import ComponentType
 
 
@@ -10,5 +8,5 @@ class BaseComponent:
         self.space_loads: list[float] = []
         self.network_loads: list[float] = []
 
-    def set_network_loads(self, num_loads: Optional[int] = None):
+    def set_network_loads(self, num_loads: int | None = None):
         pass


### PR DESCRIPTION
#### Any background context you want to provide?
The way we import local modules is only supported in python 3.10+.

Removing support for 3.9 is acceptable because other parts of UO (Opendss) already require Python 3.10.
#### What does this PR accomplish?
- Drop support for Python 3.9
- Test with Python 3.10+
#### How should this be manually tested?
CI is sufficient
#### What are the relevant tickets?
<!--Add the issue numbers like this: Resolves #100 Resolves #101 to automatically connect your PR to 1+ issues. -->
#### Screenshots (if appropriate)
