### PR TITLE
feat(ghe): Set GHEDesigner to use GeoJSON polygons

### DIFF
--- a/demos/sdk_output_skeleton_1_ghe/run/baseline_scenario/ghe_dir/sys_params_detailed_geo.json
+++ b/demos/sdk_output_skeleton_1_ghe/run/baseline_scenario/ghe_dir/sys_params_detailed_geo.json
@@ -1,0 +1,149 @@
+{
+  "buildings": [
+    {
+      "geojson_id": "8",
+      "load_model": "time_series",
+      "load_model_parameters": {
+        "time_series": {
+          "filepath": "C:\\Users\\tcharan\\Desktop\\NRELWork\\Gitrepos\\geojson-modelica-translator\\tests\\management\\data\\sdk_project_scraps\\run\\baseline_scenario\\2\\016_export_modelica_loads\\modelica.mos",
+          "delta_temp_air_cooling": 10,
+          "delta_temp_air_heating": 18,
+          "has_liquid_cooling": true,
+          "has_liquid_heating": true,
+          "has_electric_cooling": false,
+          "has_electric_heating": false,
+          "max_electrical_load": 823879000,
+          "temp_chw_return": 12,
+          "temp_chw_supply": 7,
+          "temp_hw_return": 35,
+          "temp_hw_supply": 40,
+          "temp_setpoint_cooling": 24,
+          "temp_setpoint_heating": 20
+        }
+      },
+      "ets_model": "Fifth Gen Heat Pump",
+      "fifth_gen_ets_parameters": {
+        "supply_water_temperature_building": 15,
+        "chilled_water_supply_temp": 5,
+        "hot_water_supply_temp": 50,
+        "cop_heat_pump_heating": 2.5,
+        "cop_heat_pump_cooling": 3.5,
+        "ets_pump_flow_rate": 0.0005,
+        "ets_pump_head": 10000,
+        "fan_design_flow_rate": 0.25,
+        "fan_design_head": 150
+      },
+      "photovoltaic_panels": [],
+      "diesel_generators": [],
+      "battery_banks": []
+    },
+    {
+      "geojson_id": "9",
+      "load_model": "time_series",
+      "load_model_parameters": {
+        "time_series": {
+          "filepath": "C:\\Users\\tcharan\\Desktop\\NRELWork\\Gitrepos\\geojson-modelica-translator\\tests\\management\\data\\sdk_project_scraps\\run\\baseline_scenario\\5\\016_export_modelica_loads\\modelica.mos",
+          "delta_temp_air_cooling": 10,
+          "delta_temp_air_heating": 18,
+          "has_liquid_cooling": true,
+          "has_liquid_heating": true,
+          "has_electric_cooling": false,
+          "has_electric_heating": false,
+          "max_electrical_load": 45830800,
+          "temp_chw_return": 12,
+          "temp_chw_supply": 7,
+          "temp_hw_return": 35,
+          "temp_hw_supply": 40,
+          "temp_setpoint_cooling": 24,
+          "temp_setpoint_heating": 20
+        }
+      },
+      "ets_model": "Fifth Gen Heat Pump",
+      "fifth_gen_ets_parameters": {
+        "supply_water_temperature_building": 15,
+        "chilled_water_supply_temp": 5,
+        "hot_water_supply_temp": 50,
+        "cop_heat_pump_heating": 2.5,
+        "cop_heat_pump_cooling": 3.5,
+        "ets_pump_flow_rate": 0.0005,
+        "ets_pump_head": 10000,
+        "fan_design_flow_rate": 0.25,
+        "fan_design_head": 150
+      }
+    }
+  ],
+  "district_system": {
+    "fifth_generation": {
+      "soil": {
+        "conductivity": 2.0,
+        "rho_cp": 2343493,
+        "undisturbed_temp": 18.3
+      },
+      "horizontal_piping_parameters": {
+        "hydraulic_diameter": 0.089,
+        "insulation_thickness": 0.2,
+        "insulation_conductivity": 2.3,
+        "diameter_ratio": 11,
+        "roughness": 1e-06,
+        "rho_cp": 2139000,
+        "number_of_segments": 1,
+        "buried_depth": 1.5
+      },
+      "central_pump_parameters": {
+        "pump_design_head": 60000,
+        "pump_flow_rate": 0.01
+      },
+      "ghe_parameters": {
+        "version": "0.2.5",
+        "ghe_dir": "tests\\management\\data\\sdk_project_scraps\\run\\baseline_scenario\\ghe_dir",
+        "fluid": {
+          "fluid_name": "Water",
+          "concentration_percent": 0.0,
+          "temperature": 20
+        },
+        "grout": {
+          "conductivity": 1.0,
+          "rho_cp": 3901000
+        },
+        "pipe": {
+          "inner_diameter": 0.0216,
+          "outer_diameter": 0.0266,
+          "shank_spacing": 0.0323,
+          "roughness": 1e-06,
+          "conductivity": 0.4,
+          "rho_cp": 1542000,
+          "arrangement": "singleutube"
+        },
+        "simulation": {
+          "num_months": 240
+        },
+        "geometric_constraints": {
+          "b_min": 3.0,
+          "b_max": 10.0,
+          "max_height": 135.0,
+          "min_height": 60.0,
+          "method": "rectangle"
+        },
+        "design": {
+          "method": "AREAPROPORTIONAL",
+          "flow_rate": 0.2,
+          "flow_type": "borehole",
+          "max_eft": 35.0,
+          "min_eft": 5.0
+        },
+        "ghe_specific_params": [
+          {
+            "ghe_id": "8c369df2-18e9-439a-8c25-875851c5aaf0",
+            "borehole": {
+              "buried_depth": 2.0,
+              "diameter": 0.15,
+              "length_of_boreholes": 1.0,
+              "number_of_boreholes": 5
+            }
+          }
+        ]
+      }
+    }
+  },
+  "weather": "USA_NY_Buffalo-Greater.Buffalo.Intl.AP.725280_TMY3.mos"
+}

--- a/demos/sdk_output_skeleton_1_ghe/run/baseline_scenario/ghe_dir/sys_params_detailed_geo.json
+++ b/demos/sdk_output_skeleton_1_ghe/run/baseline_scenario/ghe_dir/sys_params_detailed_geo.json
@@ -122,7 +122,7 @@
           "b_max": 10.0,
           "max_height": 135.0,
           "min_height": 60.0,
-          "method": "rectangle"
+          "method": "polygon"
         },
         "design": {
           "method": "AREAPROPORTIONAL",

--- a/thermalnetwork/projection.py
+++ b/thermalnetwork/projection.py
@@ -65,9 +65,9 @@ def lon_lat_to_polygon(polygon_lon_lat_coords, origin_lon_lat=None,
     # Unpack or auto-calculate the conversion factors
     if not conversion_factors:
         meters_to_lon, meters_to_lat = meters_to_long_lat_factors(origin_lon_lat)
-        lon_to_meters, lat_to_meters = 1.0 / meters_to_lon, 1.0 / meters_to_lat
     else:
-        lon_to_meters, lat_to_meters = conversion_factors
+        meters_to_lon, meters_to_lat = conversion_factors
+    lon_to_meters, lat_to_meters = 1.0 / meters_to_lon, 1.0 / meters_to_lat
 
     # Get the (X, Y) values for the polygon in meters
     return [((pt[0] - origin_lon_lat[0]) / lon_to_meters,
@@ -121,6 +121,22 @@ def lower_left_point(polygon):
         if point[1] < min_pt[1]:
             min_pt[1] = point[1]
     return min_pt
+
+
+def upper_right_point(polygon):
+    """
+    Get (X, Y) values for the upper right corner of the bounding rectangle for a polygon.
+
+    :param polygon: An array of (X, Y) values in any units system.
+    :return: X and Y coordinates for the upper right point around the polygon.
+    """
+    max_pt = [polygon[0][0], polygon[0][1]]
+    for point in polygon[1:]:
+        if point[0] > max_pt[0]:
+            max_pt[0] = point[0]
+        if point[1] > max_pt[1]:
+            max_pt[1] = point[1]
+    return max_pt
 
 
 def polygon_area(polygon):

--- a/thermalnetwork/tests/test_base.py
+++ b/thermalnetwork/tests/test_base.py
@@ -23,6 +23,10 @@ class BaseCase(TestCase):
             self.scenario_directory_path_1_ghe / "ghe_dir" / "sys_params.json"
         ).resolve()
 
+        self.system_parameter_path_1_ghe_geometry = (
+            self.scenario_directory_path_1_ghe / "ghe_dir" / "sys_params_detailed_geo.json"
+        ).resolve()
+
         self.geojson_file_path_2_ghe = (
             self.demos_path / "sdk_output_skeleton_2_ghe_sequential" / "network.geojson"
         ).resolve()

--- a/thermalnetwork/tests/test_network.py
+++ b/thermalnetwork/tests/test_network.py
@@ -190,10 +190,10 @@ class TestNetwork(BaseCase):
         # -- Clean up
         # Restore the original borehole length and number of boreholes.
         sys_param_ghe = json.loads(self.system_parameter_path_1_ghe_geometry.read_text())
-        proportional_ghe_specific_params = sys_param_ghe["district_system"]["fifth_generation"]["ghe_parameters"][
+        ghe_specific_params = sys_param_ghe["district_system"]["fifth_generation"]["ghe_parameters"][
             "ghe_specific_params"
         ]
-        for ghe in proportional_ghe_specific_params:
+        for ghe in ghe_specific_params:
             ghe["borehole"]["length_of_boreholes"] = self.original_borehole_length
             ghe["borehole"]["number_of_boreholes"] = self.original_num_boreholes
         with open(self.system_parameter_path_1_ghe_geometry, "w") as sys_param_file:


### PR DESCRIPTION
This change switches the package to use the GeoJSON polygons of the GHE field along with the set_geometry_constraints_bi_rectangle_constrained method **ONLY** when the system parameter file does not contain ghe_geometric_params.

I did it this way in order to introduce as few breaking changes as possible and to get all of the existing tests to pass. A new test has been added, which runs through the routine with detailed geometry from the GeoJSON.

Resolves https://github.com/NREL/ThermalNetwork/issues/44