### PR TITLE
feat(geometry): Rotate GeoJSON Polygons when a right angle is found

### DIFF
--- a/thermalnetwork/geometry.py
+++ b/thermalnetwork/geometry.py
@@ -1,0 +1,154 @@
+"""Utilities for performing geometric operations on polygons."""
+import math
+
+
+def lower_left_point(polygon):
+    """
+    Get (X, Y) values for the lower left corner of the bounding rectangle for a polygon.
+
+    :param polygon: An array of (X, Y) values in any units system.
+    :return: X and Y coordinates for the lower left point around the polygon.
+    """
+    min_pt = [polygon[0][0], polygon[0][1]]
+    for point in polygon[1:]:
+        min_pt[0] = min(point[0], min_pt[0])
+        min_pt[1] = min(point[1], min_pt[1])
+    return min_pt
+
+
+def upper_right_point(polygon):
+    """
+    Get (X, Y) values for the upper right corner of the bounding rectangle for a polygon.
+
+    :param polygon: An array of (X, Y) values in any units system.
+    :return: X and Y coordinates for the upper right point around the polygon.
+    """
+    max_pt = [polygon[0][0], polygon[0][1]]
+    for point in polygon[1:]:
+        max_pt[0] = max(point[0], max_pt[0])
+        max_pt[1] = max(point[1], max_pt[1])
+    return max_pt
+
+
+def polygon_area(polygon):
+    """
+    Get the area of polygon.
+
+    :param polygon: An array of (X, Y) values in any units system.
+    :return area: A number for the area of the polygon.
+    """
+    area = 0
+    for i, pt in enumerate(polygon):
+        area += polygon[i - 1][0] * pt[1] - polygon[i - 1][1] * pt[0]
+    return area / 2
+
+
+def vector_angle(vector_1, vector_2):
+    """
+    Get the smallest angle between two vectors.
+
+    :param vector_1: (X, Y) values for the first vector.
+    :param vector_2: (X, Y) values for the second vector.
+    :return angle: The angle between the input vectors in degrees.
+    """
+    def magnitude(vec):
+        return math.sqrt(vec[0] ** 2 + vec[1] ** 2)
+
+    def dot(v1, v2):
+        return v1[0] * v2[0] + v1[1] * v2[1]
+
+    try:
+        ang = math.acos(dot(vector_1, vector_2) / (magnitude(vector_1) * magnitude(vector_2)))
+        return math.degrees(ang)
+    except ValueError:  # python floating tolerance can cause math domain error
+        if dot(vector_1, vector_2) < 0:
+            return math.degrees(math.acos(-1))
+        return math.degrees(math.acos(1))
+    except ZeroDivisionError:  # zero-length vector
+        return 0
+
+
+def vector_angle_counterclockwise(vector_1, vector_2):
+    """
+    Get the counterclockwise angle between two vectors.
+
+    :param vector_1: (X, Y) values for the first vector.
+    :param vector_2: (X, Y) values for the second vector.
+    :return angle: The counterclockwise angle between the input vectors in degrees.
+    """
+    def determinant(v1, v2):
+        return v1[0] * v2[1] - v1[1] * v2[0]
+
+    inner = vector_angle(vector_1, vector_2)
+    det = determinant(vector_1, vector_2)
+    if det >= 0:
+        return inner  # if the det > 0 then v1 is immediately counterclockwise of v2
+    else:
+        return 360 - inner  # if the det < 0 then v2 is counterclockwise of v1
+
+
+def rotate(point, angle, origin):
+    """Rotate a point counterclockwise by a certain angle around an origin.
+
+    :param point: (X, Y) values for a point to be rotated.
+    :param angle: An angle for rotation in degrees. Positive rotates counterclockwise.
+        Negative rotates clockwise.
+    :param origin: (X, Y) values for the origin around which the point will be rotated.
+    :return rotated_point: The input point that has been rotated by the input angle.
+    """
+    trans_pt = (point[0] - origin[0], point[1] - origin[1])
+    angle_rad = math.radians(angle)
+    cos_a = math.cos(angle_rad)
+    sin_a = math.sin(angle_rad)
+    qx = cos_a * trans_pt[0] - sin_a * trans_pt[1]
+    qy = sin_a * trans_pt[0] + cos_a * trans_pt[1]
+    return (qx + origin[0], qy + origin[1])
+
+
+def rotate_polygon_to_axes(polygon):
+    """
+    Rotate a polygon to align with XY axes if the first few vertices form a right angle.
+
+    :param polygon: An array of (X, Y) values in any units system.
+    :return rotated_polygon: The input polygon that has been rotated to align
+        with XY axes.
+    """
+    def distance_to_point(pt1, pt2):
+        vec = (pt1[0] - pt2[0], pt1[1] - pt2[1])
+        return math.sqrt(vec[0] ** 2 + vec[1] ** 2)
+
+    # first make sure that the polygon is oriented counter-clockwise
+    bound_poly = polygon[0][:-1]
+    poly_area = polygon_area(bound_poly)
+    if poly_area < 0:  # clockwise polygon; reverse
+        bound_poly = list(reversed(bound_poly))
+
+    # get the point of the polygon representing the lower left corner
+    min_pt = lower_left_point(bound_poly)
+    pt_dists = []
+    for i, point in enumerate(bound_poly):
+        dist = distance_to_point(min_pt, point)
+        pt_dists.append((dist, i))
+    origin_i = [x for _, x in sorted(pt_dists, key=lambda pair: pair[0])][0]
+    origin = bound_poly[origin_i]
+    prev_pt = bound_poly[origin_i - 1]
+    next_pt = bound_poly[origin_i + 1] if origin_i < len(bound_poly) - 1 else bound_poly[0]
+
+    # check if there is a need to rotate the polygon
+    if origin[0] == min_pt[0] and origin[1] == min_pt[1]:
+        return polygon  # polygon is already oriented to XY axes
+    vec_1 = (next_pt[0] - origin[0], next_pt[1] - origin[1])
+    vec_2 = (prev_pt[0] - origin[0], prev_pt[1] - origin[1])
+    if not (89 < vector_angle(vec_1, vec_2) < 91):
+        return polygon  # polygon does not have a right angle
+
+    # calculate the angle to rotate the polygon
+    y_axis = (0, 1)
+    rot_ang = vector_angle_counterclockwise(vec_2, y_axis)
+    rot_ang = rot_ang - 360 if rot_ang > 180 else rot_ang
+
+    # rotate the polygon
+    rotated_polygon = []
+    for o_poly in polygon:
+        rotated_polygon.append([rotate(pt, rot_ang, origin) for pt in o_poly])
+    return rotated_polygon

--- a/thermalnetwork/geometry.py
+++ b/thermalnetwork/geometry.py
@@ -1,4 +1,5 @@
 """Utilities for performing geometric operations on polygons."""
+
 import math
 
 
@@ -51,6 +52,7 @@ def vector_angle(vector_1, vector_2):
     :param vector_2: (X, Y) values for the second vector.
     :return angle: The angle between the input vectors in degrees.
     """
+
     def magnitude(vec):
         return math.sqrt(vec[0] ** 2 + vec[1] ** 2)
 
@@ -76,6 +78,7 @@ def vector_angle_counterclockwise(vector_1, vector_2):
     :param vector_2: (X, Y) values for the second vector.
     :return angle: The counterclockwise angle between the input vectors in degrees.
     """
+
     def determinant(v1, v2):
         return v1[0] * v2[1] - v1[1] * v2[0]
 
@@ -113,6 +116,7 @@ def rotate_polygon_to_axes(polygon):
     :return rotated_polygon: The input polygon that has been rotated to align
         with XY axes.
     """
+
     def distance_to_point(pt1, pt2):
         vec = (pt1[0] - pt2[0], pt1[1] - pt2[1])
         return math.sqrt(vec[0] ** 2 + vec[1] ** 2)
@@ -129,7 +133,8 @@ def rotate_polygon_to_axes(polygon):
     for i, point in enumerate(bound_poly):
         dist = distance_to_point(min_pt, point)
         pt_dists.append((dist, i))
-    origin_i = [x for _, x in sorted(pt_dists, key=lambda pair: pair[0])][0]
+    sorted_i = [x for _, x in sorted(pt_dists, key=lambda pair: pair[0])]
+    origin_i = sorted_i[0]
     origin = bound_poly[origin_i]
     prev_pt = bound_poly[origin_i - 1]
     next_pt = bound_poly[origin_i + 1] if origin_i < len(bound_poly) - 1 else bound_poly[0]

--- a/thermalnetwork/ground_heat_exchanger.py
+++ b/thermalnetwork/ground_heat_exchanger.py
@@ -9,7 +9,7 @@ from rich.logging import RichHandler
 
 from thermalnetwork.base_component import BaseComponent
 from thermalnetwork.enums import ComponentType
-from thermalnetwork.projection import polygon_area
+from thermalnetwork.geometry import polygon_area
 
 logging.basicConfig(level=logging.DEBUG, format="%(message)s", datefmt="[%X]", handlers=[RichHandler()])
 logger = logging.getLogger(__name__)

--- a/thermalnetwork/network.py
+++ b/thermalnetwork/network.py
@@ -16,9 +16,12 @@ from thermalnetwork.enums import ComponentType, DesignType
 from thermalnetwork.ground_heat_exchanger import GHE
 from thermalnetwork.projection import (
     lon_lat_to_polygon,
-    lower_left_point,
     meters_to_long_lat_factors,
+)
+from thermalnetwork.geometry import (
+    lower_left_point,
     upper_right_point,
+    rotate_polygon_to_axes
 )
 from thermalnetwork.pump import Pump
 
@@ -229,6 +232,7 @@ class Network:
                     for poly in lat_long_polys:
                         coords = lon_lat_to_polygon(poly, origin_lon_lat, convert_facs)
                         ghe_polygons.append(coords)
+                    ghe_polygons = rotate_polygon_to_axes(ghe_polygons)
                     # set geometric constraints to be dictated by the polygons
                     geometric_constraints["polygons"] = ghe_polygons
                     min_pt = lower_left_point(ghe_polygons[0])

--- a/thermalnetwork/network.py
+++ b/thermalnetwork/network.py
@@ -13,15 +13,11 @@ from rich.logging import RichHandler
 from thermalnetwork.base_component import BaseComponent
 from thermalnetwork.energy_transfer_station import ETS
 from thermalnetwork.enums import ComponentType, DesignType
+from thermalnetwork.geometry import lower_left_point, rotate_polygon_to_axes, upper_right_point
 from thermalnetwork.ground_heat_exchanger import GHE
 from thermalnetwork.projection import (
     lon_lat_to_polygon,
     meters_to_long_lat_factors,
-)
-from thermalnetwork.geometry import (
-    lower_left_point,
-    upper_right_point,
-    rotate_polygon_to_axes
 )
 from thermalnetwork.pump import Pump
 

--- a/thermalnetwork/projection.py
+++ b/thermalnetwork/projection.py
@@ -1,5 +1,7 @@
 """Utilities for converting (longitude, latitude) to (X, Y) coordinates in meters."""
+
 import math
+
 from thermalnetwork.geometry import lower_left_point
 
 

--- a/thermalnetwork/projection.py
+++ b/thermalnetwork/projection.py
@@ -1,6 +1,6 @@
 """Utilities for converting (longitude, latitude) to (X, Y) coordinates in meters."""
-
 import math
+from .geometry import lower_left_point
 
 
 def meters_to_long_lat_factors(origin_lon_lat=(0, 0)):
@@ -103,44 +103,3 @@ def polygon_to_lon_lat(polygon, origin_lon_lat=(0, 0), conversion_factors=None):
 
     # get the longitude, latitude values for the polygon
     return [(origin_lon_lat[0] + pt[0] / meters_to_lon, origin_lon_lat[1] + pt[1] / meters_to_lat) for pt in polygon]
-
-
-def lower_left_point(polygon):
-    """
-    Get (X, Y) values for the lower left corner of the bounding rectangle for a polygon.
-
-    :param polygon: An array of (X, Y) values in any units system.
-    :return: X and Y coordinates for the lower left point around the polygon.
-    """
-    min_pt = [polygon[0][0], polygon[0][1]]
-    for point in polygon[1:]:
-        min_pt[0] = min(point[0], min_pt[0])
-        min_pt[1] = min(point[1], min_pt[1])
-    return min_pt
-
-
-def upper_right_point(polygon):
-    """
-    Get (X, Y) values for the upper right corner of the bounding rectangle for a polygon.
-
-    :param polygon: An array of (X, Y) values in any units system.
-    :return: X and Y coordinates for the upper right point around the polygon.
-    """
-    max_pt = [polygon[0][0], polygon[0][1]]
-    for point in polygon[1:]:
-        max_pt[0] = max(point[0], max_pt[0])
-        max_pt[1] = max(point[1], max_pt[1])
-    return max_pt
-
-
-def polygon_area(polygon):
-    """
-    Get the area of polygon.
-
-    :param polygon: An array of (X, Y) values in any units system.
-    :return area: A number for the area of the polygon.
-    """
-    area = 0
-    for i, pt in enumerate(polygon):
-        area += polygon[i - 1][0] * pt[1] - polygon[i - 1][1] * pt[0]
-    return area / 2

--- a/thermalnetwork/projection.py
+++ b/thermalnetwork/projection.py
@@ -1,6 +1,6 @@
 """Utilities for converting (longitude, latitude) to (X, Y) coordinates in meters."""
 import math
-from .geometry import lower_left_point
+from thermalnetwork.geometry import lower_left_point
 
 
 def meters_to_long_lat_factors(origin_lon_lat=(0, 0)):

--- a/thermalnetwork/tests/test_network.py
+++ b/thermalnetwork/tests/test_network.py
@@ -34,7 +34,7 @@ class TestNetwork(BaseCase):
             output_path,
         )
 
-        expected_outputs = {"8c369df2-18e9-439a-8c25-875851c5aaf0": {"num_bh": 82, "depth": 133.5}}
+        expected_outputs = {"8c369df2-18e9-439a-8c25-875851c5aaf0": {"num_bh": 77, "depth": 128.4}}
 
         self.check_outputs(output_path, expected_outputs)
         self.reset_sys_param(self.system_parameter_path_1_ghe_geometry)

--- a/thermalnetwork/tests/test_projection.py
+++ b/thermalnetwork/tests/test_projection.py
@@ -1,6 +1,7 @@
 import pytest
 
-from thermalnetwork.projection import lon_lat_to_polygon, meters_to_long_lat_factors, polygon_area, polygon_to_lon_lat
+from thermalnetwork.geometry import polygon_area
+from thermalnetwork.projection import lon_lat_to_polygon, meters_to_long_lat_factors, polygon_to_lon_lat
 
 
 def test_meters_to_long_lat_factors():


### PR DESCRIPTION
This commit adds new methods that rotate the GeoJSON polygon if it finds that the lower left corner of the polygon has a right angle. This way, GHEDesigner will place the grid of boreholes along the site boundaries, which is more spatially efficient and closer to what people would actually build.

The commit also refactors some of the methods that do pure geometry manipulation into a `geometry.py` module that is separate from the `projection.py` module that converts between lat/long and meters.

To illustrate the change that this commit makes, it effectively turns the following borehole layout that the current package produces:

![image](https://github.com/user-attachments/assets/a77378f6-00b1-4398-8440-c84b82dd2821)

.. into this:

![image](https://github.com/user-attachments/assets/0cd8e241-94ec-45f6-af1f-6015d9ad701c)
