### PR TITLE
Change CI to run on PR activity instead of push

### DIFF
--- a/.github/workflows/format_and_lint.yml
+++ b/.github/workflows/format_and_lint.yml
@@ -1,7 +1,7 @@
 name: Format & Lint
 
 # https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   ruff:

--- a/.github/workflows/format_and_lint.yml
+++ b/.github/workflows/format_and_lint.yml
@@ -1,13 +1,14 @@
 name: Format & Lint
 
-on: [ push ]
+# https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request
+on: [pull_request]
 
 jobs:
   ruff:
     strategy:
       matrix:
-        python-version: ['3.9', '3.12']
-        os: ['ubuntu-latest', 'windows-latest']
+        python-version: ["3.9", "3.12"]
+        os: ["ubuntu-latest", "windows-latest"]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/format_and_lint.yml
+++ b/.github/workflows/format_and_lint.yml
@@ -1,7 +1,7 @@
 name: Format & Lint
 
 # https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
   ruff:

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,6 +1,7 @@
 name: Test Install
 
-on: [pull_request]
+# https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request
+on: [push, pull_request]
 
 jobs:
   install:

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,7 +1,6 @@
 name: Test Install
 
-# https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   install:

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,14 +1,13 @@
 name: Test Install
 
-on: [ push ]
+on: [pull_request]
 
 jobs:
   install:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.10' ]
+        python-version: ["3.10"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,6 @@
 name: Python Testing
 
-# https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   pytest:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,7 @@
 name: Python Testing
 
-on: [pull_request]
+# https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request
+on: [push, pull_request]
 
 jobs:
   pytest:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,14 +1,13 @@
 name: Python Testing
 
-on: [ push ]
+on: [pull_request]
 
 jobs:
   pytest:
-
     strategy:
       matrix:
-        python-version: ['3.9', '3.12']
-        os: ['ubuntu-latest', 'windows-latest']
+        python-version: ["3.9", "3.12"]
+        os: ["ubuntu-latest", "windows-latest"]
 
     runs-on: ${{ matrix.os}}
     steps:


### PR DESCRIPTION
### Any background context you want to provide?
CI wasn't running automatically when PRs are made from a fork of the repo. This PR should fix that
### What does this PR accomplish?
- Update GHA workflow files to run CI on pull_request activity, not on push. Push appears to not pick up activity from a fork of the repo
### How should this be manually tested?
### What are the relevant tickets?
<!--Add the issue numbers like this: Resolves #100 Resolves #101 to automatically connect your PR to 1+ issues. -->
### Screenshots (if appropriate)
