### PR TITLE
Automatically set beginning of loop at a GHE

### DIFF
--- a/demos/sdk_output_skeleton_13_buildings/network.geojson
+++ b/demos/sdk_output_skeleton_13_buildings/network.geojson
@@ -834,8 +834,7 @@
         "type": "ThermalJunction",
         "buildingId": "10",
         "junction_type": "DES",
-        "connection_type": "Series",
-        "is_ghe_start_loop": true
+        "connection_type": "Series"
       },
       "geometry": {
         "type": "Point",

--- a/demos/sdk_output_skeleton_13_buildings/run/baseline_scenario/ghe_dir/sys_params_proportional.json
+++ b/demos/sdk_output_skeleton_13_buildings/run/baseline_scenario/ghe_dir/sys_params_proportional.json
@@ -494,7 +494,7 @@
         "insulation_thickness": 0.2,
         "insulation_conductivity": 2.3,
         "diameter_ratio": 11,
-        "roughness": 1e-6,
+        "roughness": 1e-06,
         "rho_cp": 2139000,
         "number_of_segments": 1,
         "buried_depth": 1.5
@@ -519,7 +519,7 @@
           "inner_diameter": 0.0216,
           "outer_diameter": 0.0266,
           "shank_spacing": 0.0323,
-          "roughness": 1e-6,
+          "roughness": 1e-06,
           "conductivity": 0.4,
           "rho_cp": 1542000,
           "arrangement": "singleutube"

--- a/demos/sdk_output_skeleton_13_buildings/run/baseline_scenario/ghe_dir/sys_params_upstream.json
+++ b/demos/sdk_output_skeleton_13_buildings/run/baseline_scenario/ghe_dir/sys_params_upstream.json
@@ -494,7 +494,7 @@
         "insulation_thickness": 0.2,
         "insulation_conductivity": 2.3,
         "diameter_ratio": 11,
-        "roughness": 1e-6,
+        "roughness": 1e-06,
         "rho_cp": 2139000,
         "number_of_segments": 1,
         "buried_depth": 1.5
@@ -519,7 +519,7 @@
           "inner_diameter": 0.0216,
           "outer_diameter": 0.0266,
           "shank_spacing": 0.0323,
-          "roughness": 1e-6,
+          "roughness": 1e-06,
           "conductivity": 0.4,
           "rho_cp": 1542000,
           "arrangement": "singleutube"

--- a/demos/sdk_output_skeleton_1_ghe/network.geojson
+++ b/demos/sdk_output_skeleton_1_ghe/network.geojson
@@ -795,8 +795,7 @@
       "properties": {
         "id": "0c1b5138-e3cc-4ccb-b4ff-403fad55e9c3",
         "type": "ThermalJunction",
-        "DSId": "8c369df2-18e9-439a-8c25-875851c5aaf0",
-        "is_ghe_start_loop": true
+        "DSId": "8c369df2-18e9-439a-8c25-875851c5aaf0"
       },
       "geometry": {
         "type": "Point",

--- a/demos/sdk_output_skeleton_1_ghe/run/baseline_scenario/ghe_dir/sys_params_detailed_geo.json
+++ b/demos/sdk_output_skeleton_1_ghe/run/baseline_scenario/ghe_dir/sys_params_detailed_geo.json
@@ -84,7 +84,7 @@
         "insulation_thickness": 0.2,
         "insulation_conductivity": 2.3,
         "diameter_ratio": 11,
-        "roughness": 1e-6,
+        "roughness": 1e-06,
         "rho_cp": 2139000,
         "number_of_segments": 1,
         "buried_depth": 1.5
@@ -109,7 +109,7 @@
           "inner_diameter": 0.0216,
           "outer_diameter": 0.0266,
           "shank_spacing": 0.0323,
-          "roughness": 1e-6,
+          "roughness": 1e-06,
           "conductivity": 0.4,
           "rho_cp": 1542000,
           "arrangement": "singleutube"

--- a/demos/sdk_output_skeleton_2_ghe_sequential/network.geojson
+++ b/demos/sdk_output_skeleton_2_ghe_sequential/network.geojson
@@ -279,8 +279,7 @@
             "properties": {
                 "id": "d18cf419-a301-4e1e-9694-613cff741e70",
                 "type": "ThermalJunction",
-                "DSId": "dd69549c-ecfc-4245-96dc-5b6127f34f46",
-                "is_ghe_start_loop": "true"
+                "DSId": "dd69549c-ecfc-4245-96dc-5b6127f34f46"
             },
             "geometry": {
                 "type": "Point",

--- a/demos/sdk_output_skeleton_2_ghe_staggered/network.geojson
+++ b/demos/sdk_output_skeleton_2_ghe_staggered/network.geojson
@@ -192,8 +192,7 @@
       "properties": {
         "id": "a115e9cc-7fad-4c23-b985-681fc79cdb34",
         "type": "ThermalJunction",
-        "DSId": "47fd01d3-3d72-46c0-85f2-a12854783764",
-        "is_ghe_start_loop": "true"
+        "DSId": "47fd01d3-3d72-46c0-85f2-a12854783764"
       },
       "geometry": {
         "type": "Point",

--- a/demos/sdk_output_skeleton_2_ghe_staggered/run/baseline_scenario/ghe_dir/sys_params.json
+++ b/demos/sdk_output_skeleton_2_ghe_staggered/run/baseline_scenario/ghe_dir/sys_params.json
@@ -82,7 +82,7 @@
         "insulation_thickness": 0.2,
         "insulation_conductivity": 2.3,
         "diameter_ratio": 11,
-        "roughness": 1e-6,
+        "roughness": 1e-06,
         "rho_cp": 2139000,
         "number_of_segments": 1,
         "buried_depth": 1.5
@@ -108,7 +108,7 @@
           "inner_diameter": 0.0216,
           "outer_diameter": 0.0266,
           "shank_spacing": 0.0323,
-          "roughness": 1e-6,
+          "roughness": 1e-06,
           "conductivity": 0.4,
           "rho_cp": 1542000,
           "arrangement": "singleutube"

--- a/thermalnetwork/network.py
+++ b/thermalnetwork/network.py
@@ -752,25 +752,20 @@ def run_sizer_from_cli_worker(
     reordered_features = network.reorder_connected_features(connected_features)
     logger.debug(f"Features in loop order: {reordered_features}\n")
 
-    def categorize_ids(data):
-        result = []
-        current_group = {"list_bldg_ids_in_group": [], "list_ghe_ids_in_group": []}
+    bldg_groups_per_ghe = []
+    current_group = {"list_bldg_ids_in_group": [], "list_ghe_ids_in_group": []}
 
-        for item in data:
-            if item["district_system_type"] is not None:
-                if current_group["list_bldg_ids_in_group"] or current_group["list_ghe_ids_in_group"]:
-                    result.append(current_group)
-                    current_group = {"list_bldg_ids_in_group": [], "list_ghe_ids_in_group": []}
-                current_group["list_ghe_ids_in_group"].append(item["id"])
-            else:
-                current_group["list_bldg_ids_in_group"].append(item["id"])
+    for item in reordered_features:
+        if item["district_system_type"] is not None:
+            if current_group["list_bldg_ids_in_group"] or current_group["list_ghe_ids_in_group"]:
+                bldg_groups_per_ghe.append(current_group)
+                current_group = {"list_bldg_ids_in_group": [], "list_ghe_ids_in_group": []}
+            current_group["list_ghe_ids_in_group"].append(item["id"])
+        else:
+            current_group["list_bldg_ids_in_group"].append(item["id"])
 
-        if current_group["list_bldg_ids_in_group"] or current_group["list_ghe_ids_in_group"]:
-            result.append(current_group)
-
-        return result
-
-    bldg_groups_per_ghe: list = categorize_ids(reordered_features)
+    if current_group["list_bldg_ids_in_group"] or current_group["list_ghe_ids_in_group"]:
+        bldg_groups_per_ghe.append(current_group)
 
     # save loop order to file next to sys-params for temporary use by the GMT
     # Prepending an underscore to emphasize these as temporary files

--- a/thermalnetwork/network.py
+++ b/thermalnetwork/network.py
@@ -753,19 +753,23 @@ def run_sizer_from_cli_worker(
     logger.debug(f"Features in loop order: {reordered_features}\n")
 
     bldg_groups_per_ghe = []
-    current_group = {"list_bldg_ids_in_group": [], "list_ghe_ids_in_group": []}
+    feature_group = {"list_bldg_ids_in_group": [], "list_ghe_ids_in_group": []}
 
-    for item in reordered_features:
-        if item["district_system_type"] is not None:
-            if current_group["list_bldg_ids_in_group"] or current_group["list_ghe_ids_in_group"]:
-                bldg_groups_per_ghe.append(current_group)
-                current_group = {"list_bldg_ids_in_group": [], "list_ghe_ids_in_group": []}
-            current_group["list_ghe_ids_in_group"].append(item["id"])
+    for loop_feature in reordered_features:
+        # If a feature is a GHE, start a new group
+        if loop_feature["district_system_type"] is not None:
+            if feature_group["list_bldg_ids_in_group"] or feature_group["list_ghe_ids_in_group"]:
+                bldg_groups_per_ghe.append(feature_group)
+                feature_group = {"list_bldg_ids_in_group": [], "list_ghe_ids_in_group": []}
+            # Add the GHE to the new group
+            feature_group["list_ghe_ids_in_group"].append(loop_feature["id"])
         else:
-            current_group["list_bldg_ids_in_group"].append(item["id"])
+            # Add the building to the current group
+            feature_group["list_bldg_ids_in_group"].append(loop_feature["id"])
 
-    if current_group["list_bldg_ids_in_group"] or current_group["list_ghe_ids_in_group"]:
-        bldg_groups_per_ghe.append(current_group)
+    # If the last feature group has buildings or GHEs in it, add it to the list
+    if feature_group["list_bldg_ids_in_group"] or feature_group["list_ghe_ids_in_group"]:
+        bldg_groups_per_ghe.append(feature_group)
 
     # save loop order to file next to sys-params for temporary use by the GMT
     # Prepending an underscore to emphasize these as temporary files


### PR DESCRIPTION
### Any background context you want to provide?
We had hard-coded the beginning of the thermal loop. It was easy to make mistakes and was an extra item that needed manual input. What if we start the loop at _some_ GHE and go from there, instead of specifying an _exact_ GHE?
### What does this PR accomplish?
- Remove hard-coded ghe_start_loop from code, and simply start from the first GHE found and go from there.
- Remove is_ghe_start_loop from demo geojson files
### How should this be manually tested?
Use the test outputs from our CI to generate Modelica models with the GMT, and run them by hand. This will ensure that the loop order is generated correctly and passed to the GMT as expected.

Resolves https://github.com/urbanopt/urbanopt-cli/issues/491
