### PR TITLE
Add Autosizing of Network Pipe Diameter, and Central Pump Flow Rate and Head

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,5 @@ scenarioData.js
 sqlite.err
 started.job
 stdout-energyplus
+notebooks/
+.bundle/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,10 +29,11 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-  'click ~= 8.1',
-  'ghedesigner ~= 1.5',
-  'pandas ~= 2.0',
+  "click ~= 8.1",
+  "ghedesigner ~= 1.5",
+  "pandas ~= 2.0",
   "rich ~= 13.0",
+  "SecondaryCoolantProps ~= 1.3"
 ]
 
 [project.optional-dependencies]

--- a/thermalnetwork/fluid.py
+++ b/thermalnetwork/fluid.py
@@ -1,0 +1,40 @@
+import logging
+
+from scp.ethyl_alcohol import EthylAlcohol
+from scp.ethylene_glycol import EthyleneGlycol
+from scp.methyl_alcohol import MethylAlcohol
+from scp.propylene_glycol import PropyleneGlycol
+from scp.water import Water
+
+
+def get_fluid(fluid_type: str, fluid_concentration: float = 0):
+    if fluid_concentration < 0:
+        logging.warning("Attempting to set <0 water-antifreeze mixture concentration.")
+        logging.warning("Expect fluid concentration 0 <= x <= 0.6")
+        logging.warning("Defaulting to 0.")
+        fluid_concentration = 0
+
+    fluid_name = fluid_type.upper()
+    if fluid_name == "WATER":
+        if fluid_concentration == 0:
+            return Water()
+        else:
+            logging.warning(f"Fluid \"{fluid_name}\" - attempting to set non-zero \
+                            water-antifreeze mixture concentration \"{fluid_concentration:0.3f}\".")
+            logging.warning("Defaulting to pure water.")
+            return Water()
+
+    if fluid_concentration == 0:
+        logging.warning(f"Setting fluid \"{fluid_name} with fluid-antifreeze mixture concentration = 0")
+
+    if fluid_name == "ETHYLALCOHOL":
+        return EthylAlcohol(fluid_concentration)
+    elif fluid_name == "ETHYLENEGLYCOL":
+        return EthyleneGlycol(fluid_concentration)
+    elif fluid_name == "METHYLALCOHOL":
+        return MethylAlcohol(fluid_concentration)
+    elif fluid_name == "PROPYLENEGLYCOL":
+        return PropyleneGlycol(fluid_concentration)
+    else:
+        logging.error(f"Unsupported fluid \"{fluid_name}\"")
+        assert False

--- a/thermalnetwork/fluid.py
+++ b/thermalnetwork/fluid.py
@@ -19,13 +19,13 @@ def get_fluid(fluid_type: str, fluid_concentration: float = 0):
         if fluid_concentration == 0:
             return Water()
         else:
-            logging.warning(f"Fluid \"{fluid_name}\" - attempting to set non-zero \
-                            water-antifreeze mixture concentration \"{fluid_concentration:0.3f}\".")
+            logging.warning(f'Fluid "{fluid_name}" - attempting to set non-zero \
+                            water-antifreeze mixture concentration "{fluid_concentration:0.3f}".')
             logging.warning("Defaulting to pure water.")
             return Water()
 
     if fluid_concentration == 0:
-        logging.warning(f"Setting fluid \"{fluid_name} with fluid-antifreeze mixture concentration = 0")
+        logging.warning(f'Setting fluid "{fluid_name} with fluid-antifreeze mixture concentration = 0')
 
     if fluid_name == "ETHYLALCOHOL":
         return EthylAlcohol(fluid_concentration)
@@ -36,5 +36,5 @@ def get_fluid(fluid_type: str, fluid_concentration: float = 0):
     elif fluid_name == "PROPYLENEGLYCOL":
         return PropyleneGlycol(fluid_concentration)
     else:
-        logging.error(f"Unsupported fluid \"{fluid_name}\"")
+        logging.error(f'Unsupported fluid "{fluid_name}"')
         assert False

--- a/thermalnetwork/fluid.py
+++ b/thermalnetwork/fluid.py
@@ -19,8 +19,10 @@ def get_fluid(fluid_type: str, fluid_concentration: float = 0):
         if fluid_concentration == 0:
             return Water()
         else:
-            logging.warning(f'Fluid "{fluid_name}" - attempting to set non-zero \
-                            water-antifreeze mixture concentration "{fluid_concentration:0.3f}".')
+            logging.warning(
+                f'Fluid "{fluid_name}" - attempting to set non-zero \
+                            water-antifreeze mixture concentration "{fluid_concentration:0.3f}".'
+            )
             logging.warning("Defaulting to pure water.")
             return Water()
 
@@ -37,4 +39,4 @@ def get_fluid(fluid_type: str, fluid_concentration: float = 0):
         return PropyleneGlycol(fluid_concentration)
     else:
         logging.error(f'Unsupported fluid "{fluid_name}"')
-        assert False
+        raise SyntaxError("Unsupported fluid name")

--- a/thermalnetwork/network.py
+++ b/thermalnetwork/network.py
@@ -18,7 +18,7 @@ from thermalnetwork.ground_heat_exchanger import GHE
 from thermalnetwork.pipe import Pipe
 from thermalnetwork.projection import lon_lat_to_polygon, meters_to_long_lat_factors
 from thermalnetwork.pump import Pump
-from thermalnetwork.utilities import ft_to_m, load_json, lps_to_cms, write_json
+from thermalnetwork.utilities import load_json, lps_to_cms, write_json
 
 logging.basicConfig(level=logging.DEBUG, format="%(message)s", datefmt="[%X]", handlers=[RichHandler()])
 logger = logging.getLogger(__name__)
@@ -792,7 +792,7 @@ def run_sizer_from_cli_worker(
         if "total_length" in f["properties"]:
             total_network_length += f["properties"]["total_length"]
 
-    network.total_network_pipe_length = ft_to_m(total_network_length)
+    network.total_network_pipe_length = total_network_length
 
     bldg_groups_per_ghe = []
     feature_group = {"list_bldg_ids_in_group": [], "list_ghe_ids_in_group": []}

--- a/thermalnetwork/network.py
+++ b/thermalnetwork/network.py
@@ -15,11 +15,10 @@ from thermalnetwork.energy_transfer_station import ETS
 from thermalnetwork.enums import ComponentType, DesignType
 from thermalnetwork.geometry import lower_left_point, rotate_polygon_to_axes, upper_right_point
 from thermalnetwork.ground_heat_exchanger import GHE
-from thermalnetwork.projection import (
-    lon_lat_to_polygon,
-    meters_to_long_lat_factors,
-)
+from thermalnetwork.projection import lon_lat_to_polygon, meters_to_long_lat_factors
 from thermalnetwork.pump import Pump
+from thermalnetwork.pipe import Pipe
+from thermalnetwork.utilities import ft_to_m, load_json, write_json, lps_to_cms
 
 logging.basicConfig(level=logging.DEBUG, format="%(message)s", datefmt="[%X]", handlers=[RichHandler()])
 logger = logging.getLogger(__name__)
@@ -29,15 +28,15 @@ class Network:
     def __init__(
         self, system_parameters_data: dict, geojson_data: dict, ghe_parameters_data: dict, scenario_directory_path: Path
     ) -> None:
-        """A thermal network.
+        """
+        A thermal network.
 
-        :param des_method: Design method (upstream or proportional).
-        :param components_data: List of component data.
-        :param network: List of components.
-        :param ghe_parameters: Parameters for the ground heat exchanger.
+        :param system_parameters_data: System parameters data.
         :param geojson_data: GeoJSON data object containing features.
+        :param ghe_parameters_data: Parameters for the ground heat exchanger.
         :param scenario_directory_path: Path to the URBANopt scenario directory.
         """
+
         self.des_method = None
         self.components_data: list[dict] = []
         self.network: list[BaseComponent] = []
@@ -45,6 +44,9 @@ class Network:
         self.ghe_parameters = ghe_parameters_data
         self.geojson_data = geojson_data
         self.scenario_directory_path = scenario_directory_path
+
+        # placeholders
+        self.total_network_pipe_length = 0
 
     def get_connected_features(self):
         """
@@ -628,15 +630,19 @@ class Network:
 
     def update_sys_params(self, system_parameter_path: Path, output_directory_path: Path) -> None:
         """
-        Update the existing system parameters with the new GHEDesigner output data.
+        Update the existing system parameters file with sizing data.
 
         :param system_parameter_path: Path to the existing System Parameter file.
         :param output_directory_path: Path to the output directory containing the GHEDesigner output files.
 
         This function loads the existing system parameters from the specified file,
-        updates the GHE-specific parameters with the new data from the GHEDesigner output,
-        and saves the updated system parameters back to the same file.
-        The GHE-specific parameters include the length of the boreholes and the number of boreholes.
+        updates the GHE-specific parameters, with the new data from the GHEDesigner output, updates the pipe
+        and pump parameters with autosized flow and pressures, and saves the updated
+        system parameters back to the same file.
+
+        - The GHE-specific parameters include the length of the boreholes and the number of boreholes.
+        - Pump parameters include the design head and design flow rate
+        - Pipe parameters include the hydraulic diameter
 
         The function does not return any value, as it updates the system parameters file in place.
 
@@ -644,9 +650,18 @@ class Network:
         """
 
         # Load the existing system parameters
-        sys_params: dict = json.loads(system_parameter_path.read_text())
-        ghe_params: list = sys_params["district_system"]["fifth_generation"]["ghe_parameters"]["ghe_specific_params"]
-        for ghe in ghe_params:
+        sys_params =  load_json(system_parameter_path)
+        dist_sys_params = sys_params["district_system"]["fifth_generation"]
+        ghe_params = dist_sys_params["ghe_parameters"]
+        ghe_specific_params: list = ghe_params["ghe_specific_params"]
+        pipe_params = dist_sys_params["horizontal_piping_parameters"]
+        pump_params = dist_sys_params["central_pump_parameters"]
+
+        max_num_boreholes = 0
+        bh_vol_flow = ghe_params["design"]["flow_rate"]
+
+        # update ghe parameters
+        for ghe in ghe_specific_params:
             ghe_id = ghe["ghe_id"]
             summary_data_path = output_directory_path / ghe_id / "SimulationSummary.json"
 
@@ -654,16 +669,35 @@ class Network:
                 logger.error(f"Error sizing GHE: {ghe_id}")
 
             # Get the new data from the GHEDesigner output
-            ghe_data: dict = json.loads(summary_data_path.read_text())["ghe_system"]
-            for ghe_sys_params in ghe_params:
+            ghe_data = load_json(summary_data_path)["ghe_system"]
+            for ghe_sys_params in ghe_specific_params:
                 if ghe_sys_params["ghe_id"] == ghe_id:
                     # Update system parameters dict with the new values
-                    ghe_sys_params["borehole"]["length_of_boreholes"] = ghe_data["active_borehole_length"]["value"]
-                    ghe_sys_params["borehole"]["number_of_boreholes"] = ghe_data["number_of_boreholes"]
-        with open(system_parameter_path, "w") as sys_param_file:
-            json.dump(sys_params, sys_param_file, indent=2)
-            # Restore the trailing newline
-            sys_param_file.write("\n")
+                    bh_len = ghe_data["active_borehole_length"]["value"]
+                    num_boreholes = ghe_data["number_of_boreholes"]
+                    ghe_sys_params["borehole"]["length_of_boreholes"] = bh_len
+                    ghe_sys_params["borehole"]["number_of_boreholes"] = num_boreholes
+
+                    max_num_boreholes = max(num_boreholes, max_num_boreholes)
+
+        # update pump and pipe params
+        network_design_vol_flow = lps_to_cms(bh_vol_flow) * max_num_boreholes
+        network_pipe = Pipe(
+            dimension_ratio=pipe_params["diameter_ratio"],
+            length=self.total_network_pipe_length,
+            fluid_type=ghe_params["fluid"]["fluid_name"],
+            fluid_concentration=ghe_params["fluid"]["concentration_percent"],
+            fluid_temperature=ghe_params["fluid"]["temperature"])
+
+        # we should expose this to the user at some point
+        design_pressure_loss_per_length = 300 # Pa/m
+        hydraulic_dia = network_pipe.size_hydraulic_diameter(network_design_vol_flow, design_pressure_loss_per_length)
+        pipe_params["hydraulic_diameter"] = hydraulic_dia
+
+        pump_params["pump_design_head"] = network_pipe.pressure_loss(network_design_vol_flow)
+        pump_params["pump_flow_rate"] =network_design_vol_flow
+
+        write_json(system_parameter_path, sys_params)
 
 
 def run_sizer_from_cli_worker(
@@ -683,7 +717,7 @@ def run_sizer_from_cli_worker(
         logger.warning(f"No input file found at {geojson_file_path}, aborting.")
         return 1
 
-    geojson_data: dict = json.loads(geojson_file_path.read_text())
+    geojson_data = load_json(geojson_file_path)
     # logger.debug(f"{geojson_data=}")
 
     # Check if the file exists
@@ -691,7 +725,7 @@ def run_sizer_from_cli_worker(
         logger.warning(f"No system_parameter.json file found at {system_parameter_path}, aborting.")
         return 1
 
-    system_parameters_data = json.loads(system_parameter_path.read_text())
+    system_parameters_data = load_json(system_parameter_path)
     ghe_parameters_data: dict = system_parameters_data["district_system"]["fifth_generation"]["ghe_parameters"]
 
     # Downselect the buildings in the geojson that are in the system parameters file
@@ -751,6 +785,13 @@ def run_sizer_from_cli_worker(
 
     reordered_features = network.reorder_connected_features(connected_features)
     logger.debug(f"Features in loop order: {reordered_features}\n")
+
+    total_network_length = 0
+    for idx_f, f in enumerate(geojson_data["features"]):
+        if "total_length" in f["properties"]:
+            total_network_length += f["properties"]["total_length"]
+
+    network.total_network_pipe_length = ft_to_m(total_network_length)
 
     bldg_groups_per_ghe = []
     feature_group = {"list_bldg_ids_in_group": [], "list_ghe_ids_in_group": []}

--- a/thermalnetwork/network.py
+++ b/thermalnetwork/network.py
@@ -650,7 +650,7 @@ class Network:
         """
 
         # Load the existing system parameters
-        sys_params =  load_json(system_parameter_path)
+        sys_params = load_json(system_parameter_path)
         dist_sys_params = sys_params["district_system"]["fifth_generation"]
         ghe_params = dist_sys_params["ghe_parameters"]
         ghe_specific_params: list = ghe_params["ghe_specific_params"]
@@ -687,15 +687,16 @@ class Network:
             length=self.total_network_pipe_length,
             fluid_type=ghe_params["fluid"]["fluid_name"],
             fluid_concentration=ghe_params["fluid"]["concentration_percent"],
-            fluid_temperature=ghe_params["fluid"]["temperature"])
+            fluid_temperature=ghe_params["fluid"]["temperature"],
+        )
 
         # we should expose this to the user at some point
-        design_pressure_loss_per_length = 300 # Pa/m
+        design_pressure_loss_per_length = 300  # Pa/m
         hydraulic_dia = network_pipe.size_hydraulic_diameter(network_design_vol_flow, design_pressure_loss_per_length)
         pipe_params["hydraulic_diameter"] = hydraulic_dia
 
         pump_params["pump_design_head"] = network_pipe.pressure_loss(network_design_vol_flow)
-        pump_params["pump_flow_rate"] =network_design_vol_flow
+        pump_params["pump_flow_rate"] = network_design_vol_flow
 
         write_json(system_parameter_path, sys_params)
 

--- a/thermalnetwork/network.py
+++ b/thermalnetwork/network.py
@@ -15,10 +15,10 @@ from thermalnetwork.energy_transfer_station import ETS
 from thermalnetwork.enums import ComponentType, DesignType
 from thermalnetwork.geometry import lower_left_point, rotate_polygon_to_axes, upper_right_point
 from thermalnetwork.ground_heat_exchanger import GHE
+from thermalnetwork.pipe import Pipe
 from thermalnetwork.projection import lon_lat_to_polygon, meters_to_long_lat_factors
 from thermalnetwork.pump import Pump
-from thermalnetwork.pipe import Pipe
-from thermalnetwork.utilities import ft_to_m, load_json, write_json, lps_to_cms
+from thermalnetwork.utilities import ft_to_m, load_json, lps_to_cms, write_json
 
 logging.basicConfig(level=logging.DEBUG, format="%(message)s", datefmt="[%X]", handlers=[RichHandler()])
 logger = logging.getLogger(__name__)

--- a/thermalnetwork/pipe.py
+++ b/thermalnetwork/pipe.py
@@ -1,0 +1,260 @@
+import logging
+from math import log, pi
+
+from rich.logging import RichHandler
+
+from thermalnetwork.fluid import get_fluid
+from thermalnetwork.utilities import smoothing_function, inch_to_m
+
+logging.basicConfig(level=logging.DEBUG, format="%(message)s", datefmt="[%X]", handlers=[RichHandler()])
+logger = logging.getLogger(__name__)
+
+
+class Pipe:
+
+    def __init__(self,
+                 dimension_ratio: float,
+                 length: float,
+                 fluid_type: str = "WATER",
+                 fluid_concentration: float = 0,
+                 fluid_temperature: float = 20):
+
+        self.fluid = get_fluid(fluid_type, fluid_concentration)
+        self.fluid_temp = fluid_temperature
+
+        # ratio of outer diameter to wall thickness
+        self.dimension_ratio = dimension_ratio
+
+        # set length
+        self.length = length
+
+        # placeholders
+        self.outer_diameter = None
+        self.inner_diameter = None
+
+    def set_diameters(self, outer_dia: float):
+        """
+        Sets the outer and inner diameters member variables.
+
+        :param outer_dia: outer diameter of the pipe
+        :return: inner diameter of the pipe
+        """
+        self.inner_diameter = outer_dia * (1 - 2 / self.dimension_ratio)
+        self.outer_diameter = outer_dia
+
+    def friction_factor(self, re: float) -> float:
+        """
+        Calculates the friction factor in smooth tubes
+
+        Petukhov, B.S. 1970. 'Heat transfer and friction in turbulent pipe flow with variable physical properties.'
+        In Advances in Heat Transfer, ed. T.F. Irvine and J.P. Hartnett, Vol. 6. New York Academic Press.
+
+        :param re: Reynolds number, dimensionless
+        """
+
+        # limits picked be within about 1% of actual values
+        low_reynolds = 1500
+        high_reynolds = 5000
+
+        if re < low_reynolds:
+            return self.laminar_friction_factor(re)
+        elif low_reynolds <= re < high_reynolds:
+            # pure laminar flow
+            f_low = self.laminar_friction_factor(re)
+
+            # pure turbulent flow
+            f_high = self.turbulent_friction_factor(re)
+            sigma = smoothing_function(re, a=3000, b=450)
+            return (1 - sigma) * f_low + sigma * f_high
+        else:
+            return self.turbulent_friction_factor(re)
+
+    @staticmethod
+    def laminar_friction_factor(re: float):
+        """
+        Laminar friction factor
+
+        :param re: Reynolds number
+        :return: friction factor
+        """
+
+        return 64.0 / re
+
+    @staticmethod
+    def turbulent_friction_factor(re: float):
+        """
+        Turbulent friction factor
+
+        Petukhov, B. S. (1970). Advances in Heat Transfer, volume 6, Heat transfer and
+        friction in turbulent pipe flow with variable physical properties, pages 503-564.
+        Academic Press, Inc., New York, NY.
+
+        :param re: Reynolds number
+        :return: friction factor
+        """
+
+        return (0.79 * log(re) - 1.64) ** (-2.0)
+
+    def vol_flow_rate_to_velocity(self, vol_flow_rate: float) -> float:
+        """
+        Converts volume flow rate to velocity.
+
+        :param vol_flow_rate: volume flow rate, in m3/s
+        :return: mean fluid velocity in m/s
+        """
+        pipe_inner_cross_section_area = (pi * self.inner_diameter ** 2) / 4
+        return vol_flow_rate / pipe_inner_cross_section_area
+
+    def vol_flow_rate_to_re(self, vol_flow_rate: float) -> float:
+        velocity = self.vol_flow_rate_to_velocity(vol_flow_rate)
+        density = self.fluid.density(self.fluid_temp)
+        viscosity = self.fluid.viscosity(self.fluid_temp)
+        return density * velocity * self.inner_diameter / viscosity
+
+    def pressure_loss(self, vol_flow_rate: float) -> float:
+        """
+        Pressure loss in straight pipe
+
+        :param vol_flow_rate: volume flow rate, m3/s
+        :return: pressure loss, Pa
+        """
+
+        if vol_flow_rate <= 0:
+            return 0
+
+        re = self.vol_flow_rate_to_re(vol_flow_rate)
+        velocity = self.vol_flow_rate_to_velocity(vol_flow_rate)
+        term_1 = self.friction_factor(re) * self.length / self.inner_diameter
+        term_2 = (self.fluid.density(self.fluid_temp) * velocity ** 2) / 2
+
+        return term_1 * term_2
+
+    def pressure_loss_per_length(self, vol_flow_rate, outside_diameter: float) -> float:
+        self.set_diameters(outside_diameter)
+        return self.pressure_loss(vol_flow_rate) / self.length
+
+    def size_hydraulic_diameter(self,
+                                vol_flow_rate: float,
+                                design_pressure_loss_per_length: float,
+                                return_discrete_pipe_size: bool = True,
+                                ) -> float:
+
+        """
+        Size the pipe diameter to meet the design pressure loss requirements.
+
+        :param vol_flow_rate: volumetric flow rate, in m3/s
+        :param design_pressure_loss_per_length: design pressure loss per meter, in Pa/m. Typically, this will be 100-300 Pa/m.
+        :param return_discrete_pipe_size: setting True will return a discrete pipe size that meets the design pressure
+        loss requirements. setting False will return the fractional pipe size that meets the design pressure
+        loss requirements.
+        :return:
+        """
+
+        # this is the default and likely to be the most common use case, so we'll put it first
+        if return_discrete_pipe_size:
+
+            # https://www.dropbox.com/scl/fi/68q6h2q5kmsi5e5j7cwdl/HDPE-Pipe-Dimensions.pdf?rlkey=lp0t83df3ut8uizdrftg34318&e=1&st=xjbm19cj&dl=0
+            ip_pipes = {
+                "labels": [
+                    "3/4\"",
+                    "1\"",
+                    "1-1/4\"",
+                    "1-1/2\"",
+                    "2\"",
+                    "3\"",
+                    "4\"",
+                    "5\"",
+                    "6\"",
+                    "7\"",
+                    "8\"",
+                    "10\"",
+                    "12\"",
+                    "14\"",
+                    "16\"",
+                    "18\"",
+                    "20\"",
+                    "22\"",
+                    "24\"",
+                    "26\"",
+                    "28\"",
+                    "30\"",
+                    "32\"",
+                    "34\"",
+                    "36\"",
+                    "42\"",
+                    "48\"",
+                    "54\"",
+                    "63\""
+                ],
+                "outside_diameter": [
+                    1.05,
+                    1.315,
+                    1.66,
+                    1.90,
+                    2.375,
+                    3.50,
+                    4.50,
+                    5.563,
+                    6.625,
+                    7.125,
+                    8.625,
+                    10.75,
+                    12.75,
+                    14.00,
+                    16.00,
+                    18.00,
+                    20.00,
+                    22.00,
+                    24.00,
+                    26.00,
+                    28.00,
+                    30.00,
+                    32.00,
+                    34.00,
+                    36.00,
+                    42.00,
+                    48.00,
+                    54.00,
+                    63.00
+                ]
+            }
+
+            for idx, d in enumerate(ip_pipes["outside_diameter"]):
+                pressure_loss_per_length = self.pressure_loss_per_length(vol_flow_rate, inch_to_m(d))
+                if pressure_loss_per_length < design_pressure_loss_per_length:
+                    logger.info(f"Network pipe sized to {ip_pipes["labels"][idx]}, SDR-{self.dimension_ratio}")
+                    return self.inner_diameter
+
+            logger.info(f"Network pipe sized to {ip_pipes["labels"][-1]}, SDR-{self.dimension_ratio}.")
+            logger.warning("Maximum available pipe size used. This may result in unexpected results.")
+            return self.inner_diameter
+
+        # if we've made it this far, we're going to need to search for a continuous pipe size
+        # that meets the design conditions.
+
+        ## bisection search to find size that meets design condition
+        low_od = 0.025  # meter
+        high_od = 0.5  # meter
+
+        # find high diameter limit that bounds solution
+        high_pressure_loss_per_length = self.pressure_loss_per_length(vol_flow_rate, high_od)
+        while high_pressure_loss_per_length > design_pressure_loss_per_length:
+            high_od += 0.5
+            high_pressure_loss_per_length = self.pressure_loss_per_length(vol_flow_rate, high_od)
+
+        # set test pressure loss high for first iteration
+        test_pressure_loss_per_length = 100000
+
+        # bisection search
+        pressure_loss_tolerance = 0.1  # Pa/m
+        while abs(test_pressure_loss_per_length - design_pressure_loss_per_length) > pressure_loss_tolerance:
+            test_dia = (low_od + high_od) / 2
+            test_pressure_loss_per_length = self.pressure_loss_per_length(vol_flow_rate, test_dia)
+            if (test_pressure_loss_per_length - design_pressure_loss_per_length) > 0:
+                # adjust lower bound
+                low_od = test_dia
+            else:
+                # adjust upper bound
+                high_od = test_dia
+
+        return self.inner_diameter

--- a/thermalnetwork/pipe.py
+++ b/thermalnetwork/pipe.py
@@ -11,14 +11,14 @@ logger = logging.getLogger(__name__)
 
 
 class Pipe:
-
-    def __init__(self,
-                 dimension_ratio: float,
-                 length: float,
-                 fluid_type: str = "WATER",
-                 fluid_concentration: float = 0,
-                 fluid_temperature: float = 20):
-
+    def __init__(
+        self,
+        dimension_ratio: float,
+        length: float,
+        fluid_type: str = "WATER",
+        fluid_concentration: float = 0,
+        fluid_temperature: float = 20,
+    ):
         self.fluid = get_fluid(fluid_type, fluid_concentration)
         self.fluid_temp = fluid_temperature
 
@@ -102,7 +102,7 @@ class Pipe:
         :param vol_flow_rate: volume flow rate, in m3/s
         :return: mean fluid velocity in m/s
         """
-        pipe_inner_cross_section_area = (pi * self.inner_diameter ** 2) / 4
+        pipe_inner_cross_section_area = (pi * self.inner_diameter**2) / 4
         return vol_flow_rate / pipe_inner_cross_section_area
 
     def vol_flow_rate_to_re(self, vol_flow_rate: float) -> float:
@@ -125,7 +125,7 @@ class Pipe:
         re = self.vol_flow_rate_to_re(vol_flow_rate)
         velocity = self.vol_flow_rate_to_velocity(vol_flow_rate)
         term_1 = self.friction_factor(re) * self.length / self.inner_diameter
-        term_2 = (self.fluid.density(self.fluid_temp) * velocity ** 2) / 2
+        term_2 = (self.fluid.density(self.fluid_temp) * velocity**2) / 2
 
         return term_1 * term_2
 
@@ -133,12 +133,12 @@ class Pipe:
         self.set_diameters(outside_diameter)
         return self.pressure_loss(vol_flow_rate) / self.length
 
-    def size_hydraulic_diameter(self,
-                                vol_flow_rate: float,
-                                design_pressure_loss_per_length: float,
-                                return_discrete_pipe_size: bool = True,
-                                ) -> float:
-
+    def size_hydraulic_diameter(
+        self,
+        vol_flow_rate: float,
+        design_pressure_loss_per_length: float,
+        return_discrete_pipe_size: bool = True,
+    ) -> float:
         """
         Size the pipe diameter to meet the design pressure loss requirements.
 
@@ -152,39 +152,38 @@ class Pipe:
 
         # this is the default and likely to be the most common use case, so we'll put it first
         if return_discrete_pipe_size:
-
             # https://www.dropbox.com/scl/fi/68q6h2q5kmsi5e5j7cwdl/HDPE-Pipe-Dimensions.pdf?rlkey=lp0t83df3ut8uizdrftg34318&e=1&st=xjbm19cj&dl=0
             ip_pipes = {
                 "labels": [
-                    "3/4\"",
-                    "1\"",
-                    "1-1/4\"",
-                    "1-1/2\"",
-                    "2\"",
-                    "3\"",
-                    "4\"",
-                    "5\"",
-                    "6\"",
-                    "7\"",
-                    "8\"",
-                    "10\"",
-                    "12\"",
-                    "14\"",
-                    "16\"",
-                    "18\"",
-                    "20\"",
-                    "22\"",
-                    "24\"",
-                    "26\"",
-                    "28\"",
-                    "30\"",
-                    "32\"",
-                    "34\"",
-                    "36\"",
-                    "42\"",
-                    "48\"",
-                    "54\"",
-                    "63\""
+                    '3/4"',
+                    '1"',
+                    '1-1/4"',
+                    '1-1/2"',
+                    '2"',
+                    '3"',
+                    '4"',
+                    '5"',
+                    '6"',
+                    '7"',
+                    '8"',
+                    '10"',
+                    '12"',
+                    '14"',
+                    '16"',
+                    '18"',
+                    '20"',
+                    '22"',
+                    '24"',
+                    '26"',
+                    '28"',
+                    '30"',
+                    '32"',
+                    '34"',
+                    '36"',
+                    '42"',
+                    '48"',
+                    '54"',
+                    '63"',
                 ],
                 "outside_diameter": [
                     1.05,
@@ -215,17 +214,17 @@ class Pipe:
                     42.00,
                     48.00,
                     54.00,
-                    63.00
-                ]
+                    63.00,
+                ],
             }
 
             for idx, d in enumerate(ip_pipes["outside_diameter"]):
                 pressure_loss_per_length = self.pressure_loss_per_length(vol_flow_rate, inch_to_m(d))
                 if pressure_loss_per_length < design_pressure_loss_per_length:
-                    logger.info(f"Network pipe sized to {ip_pipes["labels"][idx]}, SDR-{self.dimension_ratio}")
+                    logger.info(f"Network pipe sized to {ip_pipes['labels'][idx]}, SDR-{self.dimension_ratio}")
                     return self.inner_diameter
 
-            logger.info(f"Network pipe sized to {ip_pipes["labels"][-1]}, SDR-{self.dimension_ratio}.")
+            logger.info(f"Network pipe sized to {ip_pipes['labels'][-1]}, SDR-{self.dimension_ratio}.")
             logger.warning("Maximum available pipe size used. This may result in unexpected results.")
             return self.inner_diameter
 

--- a/thermalnetwork/pipe.py
+++ b/thermalnetwork/pipe.py
@@ -53,21 +53,21 @@ class Pipe:
         """
 
         # limits picked be within about 1% of actual values
-        low_reynolds = 1500
-        high_reynolds = 5000
+        low_reynolds = 2000
+        high_reynolds = 4000
 
         if re < low_reynolds:
             return self.laminar_friction_factor(re)
-        elif low_reynolds <= re < high_reynolds:
-            # pure laminar flow
-            f_low = self.laminar_friction_factor(re)
-
-            # pure turbulent flow
-            f_high = self.turbulent_friction_factor(re)
-            sigma = smoothing_function(re, a=3000, b=450)
-            return (1 - sigma) * f_low + sigma * f_high
-        else:
+        if re > high_reynolds:
             return self.turbulent_friction_factor(re)
+
+        # pure laminar flow
+        f_low = self.laminar_friction_factor(re)
+
+        # pure turbulent flow
+        f_high = self.turbulent_friction_factor(re)
+
+        return smoothing_function(re, low_reynolds, high_reynolds, f_low, f_high)
 
     @staticmethod
     def laminar_friction_factor(re: float):

--- a/thermalnetwork/pipe.py
+++ b/thermalnetwork/pipe.py
@@ -4,7 +4,7 @@ from math import log, pi
 from rich.logging import RichHandler
 
 from thermalnetwork.fluid import get_fluid
-from thermalnetwork.utilities import smoothing_function, inch_to_m
+from thermalnetwork.utilities import inch_to_m, smoothing_function
 
 logging.basicConfig(level=logging.DEBUG, format="%(message)s", datefmt="[%X]", handlers=[RichHandler()])
 logger = logging.getLogger(__name__)
@@ -143,9 +143,11 @@ class Pipe:
         Size the pipe diameter to meet the design pressure loss requirements.
 
         :param vol_flow_rate: volumetric flow rate, in m3/s
-        :param design_pressure_loss_per_length: design pressure loss per meter, in Pa/m. Typically, this will be 100-300 Pa/m.
-        :param return_discrete_pipe_size: setting True will return a discrete pipe size that meets the design pressure
-        loss requirements. setting False will return the fractional pipe size that meets the design pressure
+        :param design_pressure_loss_per_length: design pressure loss per meter, in Pa/m.
+        Typically, this will be 100-300 Pa/m.
+        :param return_discrete_pipe_size: setting True will return a discrete pipe size
+        that meets the design pressure loss requirements. setting False will return the
+        fractional pipe size that meets the design pressure
         loss requirements.
         :return:
         """

--- a/thermalnetwork/tests/test_pipe.py
+++ b/thermalnetwork/tests/test_pipe.py
@@ -7,7 +7,6 @@ from thermalnetwork.utilities import inch_to_m
 
 
 class TestPipe(unittest.TestCase):
-
     def test_init(self):
         # test water
         pipe = Pipe(
@@ -20,12 +19,7 @@ class TestPipe(unittest.TestCase):
         self.assertIsInstance(pipe.fluid, Water)
 
         # test propylene glycol
-        pg_pipe = Pipe(
-            dimension_ratio=11,
-            length=100,
-            fluid_type="PROPYLENEGLYCOL",
-            fluid_concentration=0.2
-        )
+        pg_pipe = Pipe(dimension_ratio=11, length=100, fluid_type="PROPYLENEGLYCOL", fluid_concentration=0.2)
 
         self.assertIsInstance(pg_pipe, Pipe)
         self.assertEqual(pg_pipe.length, 100)
@@ -47,10 +41,7 @@ class TestPipe(unittest.TestCase):
     def test_friction_factor(self):
         tol = 0.00001
 
-        pipe = Pipe(
-            dimension_ratio=11,
-            length=100
-        )
+        pipe = Pipe(dimension_ratio=11, length=100)
 
         pipe.set_diameters(0.0334)
 

--- a/thermalnetwork/tests/test_pipe.py
+++ b/thermalnetwork/tests/test_pipe.py
@@ -1,0 +1,148 @@
+import unittest
+from math import log
+
+from thermalnetwork.fluid import Water, PropyleneGlycol
+from thermalnetwork.pipe import Pipe
+from thermalnetwork.utilities import inch_to_m
+
+
+class TestPipe(unittest.TestCase):
+
+    def test_init(self):
+        # test water
+        pipe = Pipe(
+            dimension_ratio=11,
+            length=100,
+        )
+
+        self.assertIsInstance(pipe, Pipe)
+        self.assertEqual(pipe.length, 100)
+        self.assertIsInstance(pipe.fluid, Water)
+
+        # test propylene glycol
+        pg_pipe = Pipe(
+            dimension_ratio=11,
+            length=100,
+            fluid_type="PROPYLENEGLYCOL",
+            fluid_concentration=0.2
+        )
+
+        self.assertIsInstance(pg_pipe, Pipe)
+        self.assertEqual(pg_pipe.length, 100)
+        self.assertIsInstance(pg_pipe.fluid, PropyleneGlycol)
+        self.assertEqual(pg_pipe.fluid.x, 0.2)
+
+    def test_set_diameters(self):
+        pipe = Pipe(
+            dimension_ratio=11,
+            length=100,
+        )
+
+        # 1-1/4" HDPE, SDR-11. Returned value within 1.5% of tabulated value
+        outer_dia_inches = 1.66
+        pipe.set_diameters(inch_to_m(outer_dia_inches))
+        self.assertAlmostEqual(pipe.outer_diameter, inch_to_m(outer_dia_inches), delta=0.0001)
+        self.assertAlmostEqual(pipe.inner_diameter, inch_to_m(1.36), delta=0.0001)
+
+    def test_friction_factor(self):
+        tol = 0.00001
+
+        pipe = Pipe(
+            dimension_ratio=11,
+            length=100
+        )
+
+        pipe.set_diameters(0.0334)
+
+        # laminar tests
+        re = 100  # noqa: E126
+        self.assertEqual(pipe.friction_factor(re), 64.0 / re)
+
+        re = 1000
+        self.assertEqual(pipe.friction_factor(re), 64.0 / re)
+
+        re = 1400
+        self.assertEqual(pipe.friction_factor(re), 64.0 / re)
+
+        # transitional tests
+        re = 2000
+        self.assertAlmostEqual(pipe.friction_factor(re), 0.034003503, delta=tol)
+
+        re = 3000
+        self.assertAlmostEqual(pipe.friction_factor(re), 0.033446219, delta=tol)
+
+        re = 4000
+        self.assertAlmostEqual(pipe.friction_factor(re), 0.03895358, delta=tol)
+
+        # turbulent tests
+        re = 5000
+        self.assertEqual(pipe.friction_factor(re), (0.79 * log(re) - 1.64) ** (-2.0))
+
+        re = 15000
+        self.assertEqual(pipe.friction_factor(re), (0.79 * log(re) - 1.64) ** (-2.0))
+
+        re = 25000
+        self.assertEqual(pipe.friction_factor(re), (0.79 * log(re) - 1.64) ** (-2.0))
+
+    def test_vol_flow_rate_to_velocity(self):
+        pipe = Pipe(
+            dimension_ratio=11,
+            length=100,
+        )
+
+        pipe.set_diameters(0.0334)
+        self.assertAlmostEqual(pipe.vol_flow_rate_to_velocity(0.001), 1.75, delta=0.1)
+
+    def test_vol_flow_to_re(self):
+        pipe = Pipe(
+            dimension_ratio=11,
+            length=100,
+        )
+
+        pipe.set_diameters(0.0334)
+
+        # compared against: https://www.engineeringtoolbox.com/reynolds-number-d_237.html
+        self.assertAlmostEqual(pipe.vol_flow_rate_to_re(0.001), 46415, delta=1)
+
+    def test_pressure_loss(self):
+        pipe = Pipe(
+            dimension_ratio=11,
+            length=100,
+        )
+
+        pipe.set_diameters(0.0334)
+
+        # compared against: https://www.irrigationking.com/help/irrigation-resources/pressure-loss-calculators/?srsltid=AfmBOoqgG8RfzO0AQSdBNm8vPieVDT32zOppPGjUrzwsIoLN7njBDGg7
+        self.assertAlmostEqual(pipe.pressure_loss(0.001), 113185, delta=1)
+
+    def test_size_hydraulic_diameter(self):
+        pipe = Pipe(
+            dimension_ratio=11,
+            length=100,
+        )
+
+        # test to find regular pipe sizes
+        # 1 lps, sized to 1-1/2"
+        self.assertAlmostEqual(pipe.size_hydraulic_diameter(0.001, 300), 0.03948, delta=0.0001)
+
+        # 100 lps, sized to 10"
+        self.assertAlmostEqual(pipe.size_hydraulic_diameter(0.1, 300), 0.2234, delta=0.0001)
+
+        # 1000 lps (1 m3/s), sized to 24"
+        self.assertAlmostEqual(pipe.size_hydraulic_diameter(1.0, 300), 0.4987, delta=0.0001)
+
+        # 10 m3/s, sized to 63"
+        self.assertAlmostEqual(pipe.size_hydraulic_diameter(10.0, 300), 1.3092, delta=0.0001)
+
+        # 100 m3/s, sized to 63" with warning about being above max available pipe size
+        self.assertAlmostEqual(pipe.size_hydraulic_diameter(100.0, 300), 1.3092, delta=0.0001)
+
+        # test to find exact pipe sizes
+        # 1 lps
+        self.assertAlmostEqual(pipe.size_hydraulic_diameter(0.001, 300, False), 0.03611, delta=0.0001)
+
+        # 100 lps
+        self.assertAlmostEqual(pipe.size_hydraulic_diameter(0.1, 300, False), 0.2024, delta=0.0001)
+
+        # 10 m3/s
+        self.assertAlmostEqual(pipe.size_hydraulic_diameter(10.0, 300, False), 1.1671, delta=0.0001)

--- a/thermalnetwork/tests/test_pipe.py
+++ b/thermalnetwork/tests/test_pipe.py
@@ -1,7 +1,7 @@
 import unittest
 from math import log
 
-from thermalnetwork.fluid import Water, PropyleneGlycol
+from thermalnetwork.fluid import PropyleneGlycol, Water
 from thermalnetwork.pipe import Pipe
 from thermalnetwork.utilities import inch_to_m
 
@@ -46,7 +46,7 @@ class TestPipe(unittest.TestCase):
         pipe.set_diameters(0.0334)
 
         # laminar tests
-        re = 100  # noqa: E126
+        re = 100
         self.assertEqual(pipe.friction_factor(re), 64.0 / re)
 
         re = 1000

--- a/thermalnetwork/tests/test_pipe.py
+++ b/thermalnetwork/tests/test_pipe.py
@@ -57,13 +57,13 @@ class TestPipe(unittest.TestCase):
 
         # transitional tests
         re = 2000
-        self.assertAlmostEqual(pipe.friction_factor(re), 0.034003503, delta=tol)
+        self.assertAlmostEqual(pipe.friction_factor(re), 0.03200000, delta=tol)
 
         re = 3000
-        self.assertAlmostEqual(pipe.friction_factor(re), 0.033446219, delta=tol)
+        self.assertAlmostEqual(pipe.friction_factor(re), 0.03344621, delta=tol)
 
         re = 4000
-        self.assertAlmostEqual(pipe.friction_factor(re), 0.03895358, delta=tol)
+        self.assertAlmostEqual(pipe.friction_factor(re), 0.04143985, delta=tol)
 
         # turbulent tests
         re = 5000

--- a/thermalnetwork/tests/test_utilities.py
+++ b/thermalnetwork/tests/test_utilities.py
@@ -1,0 +1,10 @@
+import unittest
+
+from thermalnetwork.utilities import smoothing_function
+
+
+class TestUtilities(unittest.TestCase):
+    def test_smoothing_function(self):
+        self.assertAlmostEqual(smoothing_function(0, 0, 10, 0, 10), 0, delta=1e-3)
+        self.assertAlmostEqual(smoothing_function(5, 0, 10, 0, 10), 5, delta=1e-3)
+        self.assertAlmostEqual(smoothing_function(10, 0, 10, 0, 10), 10, delta=1e-3)

--- a/thermalnetwork/utilities.py
+++ b/thermalnetwork/utilities.py
@@ -3,17 +3,6 @@ from math import exp
 from pathlib import Path
 
 
-def ft_to_m(x: float) -> float:
-    """
-    Convert feet to meters
-
-    :param x: input value, in feet
-    :return: converted value, in meters
-    """
-
-    return x * 0.3048
-
-
 def lps_to_cms(x: float) -> float:
     """
     Convert liters per second to meters cubed per second
@@ -35,21 +24,6 @@ def inch_to_m(x_inch: float) -> float:
     return x_inch * 0.0254
 
 
-def smoothing_function(x: float, a: float, b: float) -> float:
-    """
-    Sigmoid smoothing function
-
-    https://en.wikipedia.org/wiki/Sigmoid_function
-
-    :param x: independent variable
-    :param a: fitting parameter 1
-    :param b: fitting parameter 2
-    :return: float between 0-1
-    """
-
-    return 1 / (1 + exp(-(x - a) / b))
-
-
 def write_json(write_path: Path, input_dict: dict, indent: int = 2, sort_keys: bool = False) -> None:
     with write_path.open("w") as f:
         f.write(json.dumps(input_dict, sort_keys=sort_keys, indent=indent, separators=(",", ": ")))
@@ -57,3 +31,37 @@ def write_json(write_path: Path, input_dict: dict, indent: int = 2, sort_keys: b
 
 def load_json(read_path: Path) -> dict:
     return json.loads(read_path.read_text())
+
+
+def smoothing_function(x, x_low_limit, x_high_limit, y_low_limit, y_high_limit) -> float:
+    """
+    Sigmoid smoothing function
+
+    https://en.wikipedia.org/wiki/Sigmoid_function
+
+    :param x: independent variable
+    :param x_low_limit: lower limit on x range
+    :param x_high_limit: upper limit on x range
+    :param y_low_limit: lower limit on y range
+    :param y_high_limit: upper limit on y range
+    :return smoothed value between x_low_limit and x_high_limit. returns y_low_limit and y_high_limit
+    below and above the x_low_limit and x_high_limit, respectively.
+    """
+
+    # check lower and upper bounds
+    if x < x_low_limit:
+        return y_low_limit
+
+    if x > x_high_limit:
+        return y_high_limit
+
+    # interp x range to value between -10 to 10 for sigmoid function
+    s_x_max = 10
+    s_x_min = -10
+    s_x = (x - x_low_limit) / (x_high_limit - x_low_limit) * (s_x_max - s_x_min) + s_x_min
+
+    # get sigmoid function for interpolation between real y values
+    s_y = 1 / (1 + exp(-s_x))
+
+    # finally interpolate to the final value
+    return s_y * (y_high_limit - y_low_limit) + y_low_limit

--- a/thermalnetwork/utilities.py
+++ b/thermalnetwork/utilities.py
@@ -1,0 +1,59 @@
+import json
+from math import exp
+from pathlib import Path
+
+
+def ft_to_m(x: float) -> float:
+    """
+    Convert feet to meters
+
+    :param x: input value, in feet
+    :return: converted value, in meters
+    """
+
+    return x * 0.3048
+
+
+def lps_to_cms(x: float) -> float:
+    """
+    Convert liters per second to meters cubed per second
+
+    :param x: input value, in liters per second
+    :return: converted value, in meters cubed per second
+    """
+
+    return x * 0.001
+
+
+def inch_to_m(x_inch: float) -> float:
+    """
+    Convert inches to meters
+
+    :param x_inch: value to convert, inches
+    :return: float value, meters
+    """
+    return x_inch * 0.0254
+
+
+def smoothing_function(x: float, a: float, b: float) -> float:
+    """
+    Sigmoid smoothing function
+
+    https://en.wikipedia.org/wiki/Sigmoid_function
+
+    :param x: independent variable
+    :param a: fitting parameter 1
+    :param b: fitting parameter 2
+    :return: float between 0-1
+    """
+
+    return 1 / (1 + exp(-(x - a) / b))
+
+
+def write_json(write_path: Path, input_dict: dict, indent: int = 2, sort_keys: bool = False) -> None:
+    with write_path.open("w") as f:
+        f.write(json.dumps(input_dict, sort_keys=sort_keys, indent=indent, separators=(",", ": ")))
+
+
+def load_json(read_path: Path) -> dict:
+    return json.loads(read_path.read_text())


### PR DESCRIPTION
Not being able to have reasonable flow rates and pipe sizes for the primary network piping has caused problems with the Modelica simulations. This adds basic pipe and pump sizing capabilities to the package.

Process:
1. Mine the total network pipe length from the geoJSON file.
2. After GHE sizing, loop over all instances and find the GHE with the highest number of boreholes (`num_bh_max`).
3. Take the user-defined, per-borehole flow rate and the multiply by `num_bh_max` to find the max network flow rate. This approach assumes that the biggest GHE will be the loop component with the highest energy transfer demands*, and thus it sets the loop design flow rate.
4. Use that flow rate and a pipe model with capabilities to compute the pressure loss as a function of flow rate, and then search to find the pipe size that meets our design condition, which currently is hard coded to 300 Pa/m** (100-300 Pa/m are reasonable design values). After that, we search through all the generally available US pipe sizes until we have a pressure loss per unit network length at the design flow rate that is less than the design condition***.
5. Update the sys params file with the update pipe size, and updated pump flow and head values.

\* it's a passive component, so it really doesn't have demands, but this is what we're doing for now.
** this should be exposed as a user parameter at some point
*** this should result in a pipe that is within the 100-300 Pa/m range of acceptable values. This approach also neglects the pressure loss in each GHE, but the GHE are on branch pumps anyway. We still need a better approach for sizing those pumps.