### PR TITLE
Change pandas resample syntax to address deprecation warning

### DIFF
--- a/thermalnetwork/network.py
+++ b/thermalnetwork/network.py
@@ -419,7 +419,7 @@ class Network:
         )
         space_loads_df = pd.concat([space_loads_df, new_data])
         # interpolate data to hourly
-        space_loads_df = space_loads_df.resample("H").interpolate(method="linear")
+        space_loads_df = space_loads_df.resample("h").interpolate(method="linear")
         # keep only 8760
         space_loads_df = space_loads_df.iloc[:8760]
         ets.space_loads = space_loads_df["TotalSensibleLoad"]


### PR DESCRIPTION
### Any background context you want to provide?
Our test suite was emitting a deprecation warning from Pandas. It was irritating.
### What does this PR accomplish?
Change the pandas.resample syntax to the new way. No change to functionality, just maintenance.
### How should this be manually tested?
CI is sufficient
### What are the relevant tickets?
<!--Add the issue numbers like this: Resolves #100 Resolves #101 to automatically connect your PR to 1+ issues. -->
### Screenshots (if appropriate)
