### PR TITLE
Use horizontal pipe pressure from sys-param file

### DIFF
--- a/demos/sdk_output_skeleton_13_buildings/run/baseline_scenario/ghe_dir/sys_params_proportional.json
+++ b/demos/sdk_output_skeleton_13_buildings/run/baseline_scenario/ghe_dir/sys_params_proportional.json
@@ -494,6 +494,7 @@
         "insulation_thickness": 0.2,
         "insulation_conductivity": 2.3,
         "diameter_ratio": 11,
+        "pressure_drop_per_meter": 300,
         "roughness": 1e-06,
         "rho_cp": 2139000,
         "number_of_segments": 1,

--- a/demos/sdk_output_skeleton_13_buildings/run/baseline_scenario/ghe_dir/sys_params_upstream.json
+++ b/demos/sdk_output_skeleton_13_buildings/run/baseline_scenario/ghe_dir/sys_params_upstream.json
@@ -494,6 +494,7 @@
         "insulation_thickness": 0.2,
         "insulation_conductivity": 2.3,
         "diameter_ratio": 11,
+        "pressure_drop_per_meter": 300,
         "roughness": 1e-06,
         "rho_cp": 2139000,
         "number_of_segments": 1,

--- a/demos/sdk_output_skeleton_1_ghe/run/baseline_scenario/ghe_dir/sys_params.json
+++ b/demos/sdk_output_skeleton_1_ghe/run/baseline_scenario/ghe_dir/sys_params.json
@@ -142,8 +142,8 @@
             "borehole": {
               "buried_depth": 2.0,
               "diameter": 0.15,
-              "length_of_boreholes": 106.65833747420167,
-              "number_of_boreholes": 75
+              "length_of_boreholes": 1.0,
+              "number_of_boreholes": 5
             }
           }
         ]

--- a/demos/sdk_output_skeleton_1_ghe/run/baseline_scenario/ghe_dir/sys_params.json
+++ b/demos/sdk_output_skeleton_1_ghe/run/baseline_scenario/ghe_dir/sys_params.json
@@ -84,6 +84,7 @@
         "insulation_thickness": 0.2,
         "insulation_conductivity": 2.3,
         "diameter_ratio": 11,
+        "pressure_drop_per_meter": 300,
         "roughness": 1e-06,
         "rho_cp": 2139000,
         "number_of_segments": 1,
@@ -141,8 +142,8 @@
             "borehole": {
               "buried_depth": 2.0,
               "diameter": 0.15,
-              "length_of_boreholes": 1.0,
-              "number_of_boreholes": 5
+              "length_of_boreholes": 106.65833747420167,
+              "number_of_boreholes": 75
             }
           }
         ]

--- a/demos/sdk_output_skeleton_1_ghe/run/baseline_scenario/ghe_dir/sys_params_detailed_geo.json
+++ b/demos/sdk_output_skeleton_1_ghe/run/baseline_scenario/ghe_dir/sys_params_detailed_geo.json
@@ -84,6 +84,7 @@
         "insulation_thickness": 0.2,
         "insulation_conductivity": 2.3,
         "diameter_ratio": 11,
+        "pressure_drop_per_meter": 300,
         "roughness": 1e-06,
         "rho_cp": 2139000,
         "number_of_segments": 1,

--- a/demos/sdk_output_skeleton_2_ghe_sequential/run/baseline_scenario/ghe_dir/sys_params.json
+++ b/demos/sdk_output_skeleton_2_ghe_sequential/run/baseline_scenario/ghe_dir/sys_params.json
@@ -124,6 +124,7 @@
         "insulation_thickness": 0.2,
         "insulation_conductivity": 2.3,
         "diameter_ratio": 11,
+        "pressure_drop_per_meter": 300,
         "roughness": 1e-06,
         "rho_cp": 2139000,
         "number_of_segments": 1,

--- a/demos/sdk_output_skeleton_2_ghe_staggered/run/baseline_scenario/ghe_dir/sys_params.json
+++ b/demos/sdk_output_skeleton_2_ghe_staggered/run/baseline_scenario/ghe_dir/sys_params.json
@@ -82,6 +82,7 @@
         "insulation_thickness": 0.2,
         "insulation_conductivity": 2.3,
         "diameter_ratio": 11,
+        "pressure_drop_per_meter": 300,
         "roughness": 1e-06,
         "rho_cp": 2139000,
         "number_of_segments": 1,

--- a/thermalnetwork/network.py
+++ b/thermalnetwork/network.py
@@ -690,8 +690,9 @@ class Network:
             fluid_temperature=ghe_params["fluid"]["temperature"],
         )
 
-        # we should expose this to the user at some point
-        design_pressure_loss_per_length = 300  # Pa/m
+        design_pressure_loss_per_length = dist_sys_params["horizontal_piping_parameters"].get(
+            "pressure_drop_per_meter", 300
+        )  # Pa/m, defaults to 300 if not in sys_params
         hydraulic_dia = network_pipe.size_hydraulic_diameter(network_design_vol_flow, design_pressure_loss_per_length)
         pipe_params["hydraulic_diameter"] = hydraulic_dia
 

--- a/thermalnetwork/tests/test_base.py
+++ b/thermalnetwork/tests/test_base.py
@@ -71,8 +71,14 @@ class BaseCase(TestCase):
         self.test_outputs_path = here.resolve() / "test_outputs"
         self.test_outputs_path.mkdir(exist_ok=True)
 
-        # Save the original borehole length and number of boreholes, so they can be restored after the tests run.
+        # Save the original sys-param data, so they can be restored after the tests run.
         sys_param_1_ghe = json.loads(self.system_parameter_path_1_ghe.read_text())
+
+        district_params = sys_param_1_ghe["district_system"]["fifth_generation"]
+        self.original_hydraulic_diameter = district_params["horizontal_piping_parameters"]["hydraulic_diameter"]
+        self.original_pump_design_head = district_params["central_pump_parameters"]["pump_design_head"]
+        self.original_pump_flow_rate = district_params["central_pump_parameters"]["pump_flow_rate"]
+
         one_ghe_specific_params = sys_param_1_ghe["district_system"]["fifth_generation"]["ghe_parameters"][
             "ghe_specific_params"
         ]
@@ -94,6 +100,16 @@ class BaseCase(TestCase):
 
     def reset_sys_param(self, sys_param_path: Path):
         sys_param = json.loads(sys_param_path.read_text())
+        sys_param["district_system"]["fifth_generation"]["horizontal_piping_parameters"]["hydraulic_diameter"] = (
+            self.original_hydraulic_diameter
+        )
+        sys_param["district_system"]["fifth_generation"]["central_pump_parameters"]["pump_design_head"] = (
+            self.original_pump_design_head
+        )
+        sys_param["district_system"]["fifth_generation"]["central_pump_parameters"]["pump_flow_rate"] = (
+            self.original_pump_flow_rate
+        )
+
         ghe_specific_params = sys_param["district_system"]["fifth_generation"]["ghe_parameters"]["ghe_specific_params"]
 
         for idx, _ in enumerate(ghe_specific_params):


### PR DESCRIPTION
### Any background context you want to provide?
The pressure drop per length of pipe was hard-coded. It was also being hard-coded in the Modelica models, and they did not match. The GMT [will soon](https://github.com/urbanopt/geojson-modelica-translator/pull/700) have pressure drop per meter as a sys-param value, which we can use here. Not only will this allow users to adjust to their specific circumstance, but it will also prevent inconsistent behavior among these two packages

### What does this PR accomplish?
- Reads the pressure drop of horizontal piping from the sys-param file
    - Uses a default value if it's not found
- Updates our tests to also reset auto-sized pipes back to their original values after a test has run.
### How should this be manually tested?
1. Update the value of `pressure_drop_per_meter` in a sys-param file
1. Add a print statement [here](https://github.com/NREL/ThermalNetwork/blob/horiz-pressure-drop/thermalnetwork/network.py#L696) to confirm that `design_pressure_loss_per_length` is being read properly
2. Run the cli by hand (just running a test doesn't print to stdout for me)
3. Confirm the printed value is the same as the sys-param file
### What are the relevant tickets?
Not a ticket, but it does address the TODO in the code.
