### PR TITLE
Simplify logging by switching to Loguru

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,8 @@ classifiers = [
 dependencies = [
   "click ~= 8.1",
   "ghedesigner @ git+https://github.com/BETSRG/GHEDesigner.git@4bd8959676599c098e97a52d4eedbf86b576c7fe",
+  "loguru ~= 0.7",
   "pandas ~= 2.0",
-  "rich ~= 13.0",
   "SecondaryCoolantProps ~= 1.3",
   "scipy ~= 1.15"
 ]

--- a/thermalnetwork/ground_heat_exchanger.py
+++ b/thermalnetwork/ground_heat_exchanger.py
@@ -265,6 +265,6 @@ class GHE(BaseComponent):
         # size ghe
         logger.debug("running ghe sizing")
         run(ghe_input_file, ghe_dir)
-        logger.debug(f"ghe sizing data written to {ghe_dir.resolve()}")
+        logger.success(f"ghe sizing data written to {ghe_dir.resolve()}")
 
         self.update_config(ghe_dir)

--- a/thermalnetwork/ground_heat_exchanger.py
+++ b/thermalnetwork/ground_heat_exchanger.py
@@ -1,17 +1,13 @@
-import logging
 import shutil
 from pathlib import Path
 
 from ghedesigner.main import run
-from rich.logging import RichHandler
+from loguru import logger
 
 from thermalnetwork.base_component import BaseComponent
 from thermalnetwork.enums import ComponentType, GHEDesignType
 from thermalnetwork.geometry import get_boundary_points, polygon_area
 from thermalnetwork.utilities import load_json, write_json
-
-logging.basicConfig(level=logging.DEBUG, format="%(message)s", datefmt="[%X]", handlers=[RichHandler()])
-logger = logging.getLogger(__name__)
 
 
 class GHE(BaseComponent):

--- a/thermalnetwork/network.py
+++ b/thermalnetwork/network.py
@@ -1,4 +1,3 @@
-import logging
 import sys
 from importlib.metadata import version
 from pathlib import Path
@@ -6,7 +5,7 @@ from pathlib import Path
 import click
 import numpy as np
 import pandas as pd
-from rich.logging import RichHandler
+from loguru import logger
 
 from thermalnetwork import HOURS_IN_YEAR
 from thermalnetwork.base_component import BaseComponent
@@ -18,9 +17,6 @@ from thermalnetwork.pipe import Pipe
 from thermalnetwork.projection import lon_lat_to_polygon, meters_to_long_lat_factors
 from thermalnetwork.pump import Pump
 from thermalnetwork.utilities import load_json, lps_to_cms, write_json
-
-logging.basicConfig(level=logging.DEBUG, format="%(message)s", datefmt="[%X]", handlers=[RichHandler()])
-logger = logging.getLogger(__name__)
 
 
 class Network:

--- a/thermalnetwork/pipe.py
+++ b/thermalnetwork/pipe.py
@@ -1,14 +1,10 @@
-import logging
 from math import log, pi
 
-from rich.logging import RichHandler
+from loguru import logger
 
 from thermalnetwork.enums import FluidTypes
 from thermalnetwork.fluid import get_fluid
 from thermalnetwork.utilities import inch_to_m, smoothing_function
-
-logging.basicConfig(level=logging.DEBUG, format="%(message)s", datefmt="[%X]", handlers=[RichHandler()])
-logger = logging.getLogger(__name__)
 
 
 class Pipe:


### PR DESCRIPTION
### Any background context you want to provide?
Something changed in a recent version of `Rich`, which means our logging no longer printed to stdout the way it used to. Instead of troubleshooting and updating the config, I am abandoning [Rich](https://rich.readthedocs.io/en/stable/logging.html) in favor of [Loguru](https://loguru.readthedocs.io/en/stable/overview.html). Rich logging, while very powerful, is complex. Switching to loguru gets us all the functionality we could ever need (I think), without any of the config required.
### What does this PR accomplish?
Replace the Rich handler for logging with the Loguru package for all logging.
### How should this be manually tested?
Call any test from `main` branch with a `-s` suffix (to show the output during a test), then do the same from this branch. Observe the difference in log output to stdout. For example: `pytest thermalnetwork/tests/test_network.py::TestNetwork::test_network_one_ghe -s`
