### PR TITLE
Minimize changes from original loop_order output to enable additional heat sources

### DIFF
--- a/thermalnetwork/network.py
+++ b/thermalnetwork/network.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+from collections import defaultdict
 from importlib.metadata import version
 from pathlib import Path
 
@@ -747,22 +748,47 @@ def run_sizer_from_cli_worker(
 
     network.total_network_pipe_length = total_network_length
 
-    loop_order_list = []
+    bldg_groups_per_source = []
+    feature_group = defaultdict(list)
+
+    # Source type to field name
+    source_types = {
+        "Ground Heat Exchanger": "list_ghe_ids_in_group",
+        "Central Ambient Water": "list_source_ids_in_group",
+    }
+
+    def strip_empty_lists(group_dict):
+        """Return a dict with only non-empty lists."""
+        return {k: v for k, v in group_dict.items() if v}
+
+    def group_has_required_data(group):
+        """Check if the group has at least one source and one building."""
+        has_buildings = bool(group["list_bldg_ids_in_group"])
+        has_any_source = bool(group["list_ghe_ids_in_group"] or group["list_source_ids_in_group"])
+        return has_buildings and has_any_source
 
     for feature in reordered_features:
-        if feature["type"] == "Building":
-            entry_type = "building"
-        elif any("waste heat source" in s.lower() for s in feature["properties"].get("equipment", [])):
-            entry_type = "source"
-        elif feature["district_system_type"] == "Ground Heat Exchanger":
-            entry_type = "ghe"
+        print(feature["name"])
+        district_type = feature["district_system_type"]
 
-        loop_order_list.append({"name": feature["id"], "type": entry_type})
+        if district_type in source_types:
+            # If this starts a new group (previous group had buildings), close it
+            if group_has_required_data(feature_group):
+                bldg_groups_per_source.append(strip_empty_lists(feature_group))
+                feature_group = defaultdict(list)
+            feature_group[source_types[district_type]].append(feature["id"])
+        else:
+            # buildings are always added to the current group
+            feature_group["list_bldg_ids_in_group"].append(feature["id"])
+
+    # Finish last group if valid
+    if group_has_required_data(feature_group):
+        bldg_groups_per_source.append(strip_empty_lists(feature_group))
 
     # save loop order to file next to sys-params for temporary use by the GMT
-    # Prepending an underscore to emphasize these as temporary files
+    # Prepending an underscore to emphasize these as temporary files not for human use
     loop_order_filepath = system_parameter_path.parent.resolve() / "_loop_order.json"
-    write_json(loop_order_filepath, loop_order_list)
+    write_json(loop_order_filepath, bldg_groups_per_source)
 
     # convert geojson type "Building","District System" to "ENERGYTRANSFERSTATION",
     network_data: list[dict] = network.convert_features(connected_features)
@@ -781,9 +807,12 @@ def run_sizer_from_cli_worker(
         else:
             logger.error(f"Unsupported component type, {comp_type_str}")
 
+    # This is the call to GHED, which takes the most time.
     network.size_ghe(output_directory_path)
     network.size_network(system_parameter_path)
     network.update_sys_params(system_parameter_path, output_directory_path)
+
+    logger.info("\nSizing completed successfully.")
 
     return 0
 

--- a/thermalnetwork/network.py
+++ b/thermalnetwork/network.py
@@ -748,7 +748,7 @@ def run_sizer_from_cli_worker(
 
     network.total_network_pipe_length = total_network_length
 
-    bldg_groups_per_source = []
+    loop_order_list = []
     feature_group = defaultdict(list)
 
     # Source type to field name
@@ -774,7 +774,7 @@ def run_sizer_from_cli_worker(
         if district_type in source_types:
             # If this starts a new group (previous group had buildings), close it
             if group_has_required_data(feature_group):
-                bldg_groups_per_source.append(strip_empty_lists(feature_group))
+                loop_order_list.append(strip_empty_lists(feature_group))
                 feature_group = defaultdict(list)
             feature_group[source_types[district_type]].append(feature["id"])
         else:
@@ -783,12 +783,12 @@ def run_sizer_from_cli_worker(
 
     # Finish last group if valid
     if group_has_required_data(feature_group):
-        bldg_groups_per_source.append(strip_empty_lists(feature_group))
+        loop_order_list.append(strip_empty_lists(feature_group))
 
     # save loop order to file next to sys-params for temporary use by the GMT
     # Prepending an underscore to emphasize these as temporary files not for human use
     loop_order_filepath = system_parameter_path.parent.resolve() / "_loop_order.json"
-    write_json(loop_order_filepath, bldg_groups_per_source)
+    write_json(loop_order_filepath, loop_order_list)
 
     # convert geojson type "Building","District System" to "ENERGYTRANSFERSTATION",
     network_data: list[dict] = network.convert_features(connected_features)


### PR DESCRIPTION
### Any background context you want to provide?
The previous efforts to improve the `_loop_order.json` file that GMT consumes were powerful but required a lot of changes in GMT to support. By minimizing the changes to that file, we can enable additional heat sources in a network without requiring a large re-write of the GMT code to generate Modelica models.
### What does this PR accomplish?
Changes how we write the loop_order dict to include heat sources without changing the structure significantly from the original technique.
### How should this be manually tested?
Run a test from test_network.py. Use Jing's multi-waste-heat branch of the GMT to consume the `_loop_order.json` file that is produced from that test to generate a Modelica model. If it simulates (especially if OM can do it!) we are successful.
